### PR TITLE
Update processing of config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -132,7 +132,9 @@ func readConfig(configFile string) (map[string]*Layout, error) {
 	for _, layout := range layouts {
 		spec := layout.DefaultSpec
 		for _, container := range layout.Versions {
-			container.Path = layout.Path
+			if container.Path == "" {
+				container.Path = layout.Path	
+			}			
 			container.Meta.Annotations = merge(container.Meta.Annotations, layout.Meta.Annotations)
 			container.Meta.Labels = merge(container.Meta.Labels, layout.Meta.Labels)
 			container.Volumes = layout.Volumes


### PR DESCRIPTION
Update processing of config in config.go file to be able to have different paths in main browser layout and specific browser version spec.
Mainly it is useful while testing both on chrome desktop and mobile at the same time.
Example config for this case is
```
chrome:
  defaultVersion: "84.0"
  path: "/"
  meta:
    annotations:
      k8s.v1.cni.cncf.io/networks: bridge-conf-1
  kernelCaps:
  - SYS_ADMIN
  volumes:
    - name: kvm
      hostPath:
       path: /dev/kvm       
  versions:
    '84.0':
      image: selenoid/vnc:chrome_84.0
      spec:
       resources:
         requests:
           memory: 500Mi
           cpu: '0.5'
         limits:
           memory: 1.5Gi
           cpu: '1'
    '90.0':
      image: selenoid/vnc:chrome_90.0
      spec:
       resources:
         requests:
           memory: 500Mi
           cpu: '0.5'
         limits:
           memory: 1.5Gi
           cpu: '1'
    'mobile-86.0':
      image: selenoid/chrome-mobile:86.0
      path: "/wd/hub"
      privileged: true
      spec:
      volumeMounts:
        - name: kvm
          mountPath: /dev/kvm
       resources:
         requests:
           memory: 500Mi
           cpu: '0.5'
         limits:
           memory: 3.5Gi
           cpu: '2'         
```
In this case both mobile and desktop should be in the same browser layout but paths should be different, because mobile chrome is using appium (it exposes "/wd/hub" path) and desktop chrome is using default path "/", because we directly connect to chromedriver executable.