### PR TITLE
Add MCP (Model Context Protocol) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ A stateless Selenium hub for Kubernetes that creates a browser resource per sess
   - [Example payload](#example-payload)
   - [Behavioral notes](#behavioral-notes)
 - [Playwright (experimental)](#playwright-experimental)
+- [MCP (experimental)](#mcp-experimental)
+  - [Create an MCP session](#create-an-mcp-session)
+  - [Proxying MCP traffic](#proxying-mcp-traffic)
+  - [Terminating an MCP session](#terminating-an-mcp-session)
+  - [MCP Playwright example](#mcp-playwright-example)
+  - [MCP Selenium example](#mcp-selenium-example)
 - [Basic authentication](#basic-authentication)
 - [Build and image workflow](#build-and-image-workflow)
 - [Deployment](#deployment)
@@ -57,10 +63,13 @@ Selenosis exposes Selenium-compatible endpoints on both `/` and `/wd/hub`.
 | `*` | `/session/{sessionId}/*` or `/wd/hub/session/{sessionId}/*` | Proxy all session traffic (HTTP and WebSocket). |
 | `GET` | `/status` or `/wd/hub/status` | Simple service status response. |
 | `WS` | `/playwright/{name}/{version}` | Creates and proxies WS traffic. |
+| `POST` | `/mcp` | MCP Streamable HTTP transport. With no `Mcp-Session-Id` header and `?browser=<name>&version=<version>` it creates a browser and initializes a session; otherwise routed by `Mcp-Session-Id`. |
+| `GET` | `/mcp` | MCP Streamable HTTP transport — server-initiated stream (routed by `Mcp-Session-Id`). |
+| `DELETE` | `/mcp` | Terminate an MCP session and tear down its browser (routed by `Mcp-Session-Id`). |
 | `*` | `/selenosis/v1/sessions/{sessionId}/proxy/http/*` | Internal HTTP-only proxy used by Seleniferous. |
 
 ## Request flow
-1. Client calls `POST /wd/hub/session` with W3C capabilities or `WS /playwright/{name}/{version}`.
+1. Client calls `POST /wd/hub/session` with W3C capabilities, `WS /playwright/{name}/{version}`, or `POST /mcp?browser=<name>&version=<version>}` (MCP `initialize`).
 2. Selenosis creates a `Browser` resource via `browser-service`.
 3. When the browser pod is `Running`, Selenosis maps its IP to a UUID session id.
 4. All session requests are proxied to the sidecar `seleniferous` in that pod.
@@ -333,6 +342,117 @@ await browser.close();
 - Invalid JSON results in the Browser being marked as **Failed**.
 - Options are applied when the Pod is created.
 
+## Error responses
+
+When proxying to a browser pod fails, Selenosis maps the failure to a status code that lets clients react correctly. A pod that is **unreachable** (for example, torn down after the idle timeout) is detected as a connection/dial failure to the sidecar:
+
+| Endpoint | Pod unreachable | Other proxy failure |
+| --- | --- | --- |
+| `POST /session` | `500` Selenium `session not created` | `500` Selenium `session not created` |
+| `* /session/{sessionId}/*` (HTTP) | `404` Selenium `invalid session id` | `500` Selenium `unknown error` |
+| `/selenosis/v1/.../proxy/http/*` | `404` `session not found` | `500` |
+| `POST /mcp` (initialize) | `500` | `500` |
+| `POST`/`GET`/`DELETE /mcp` (routed by `Mcp-Session-Id`) | `404` `session not found` | `500` |
+
+For session-scoped endpoints an unreachable pod returns `404` so the client can tell the session no longer exists and start a new one. WebSocket endpoints (BiDi/CDP/Playwright) are not covered by this mapping — a failed upstream dial closes the connection.
+
+## MCP (experimental)
+
+Selenosis supports the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) for Playwright and Selenium MCP servers running inside browser pods.
+
+The MCP server runs inside the browser container (not in seleniferous). Selenosis creates the browser pod and proxies MCP traffic through the seleniferous sidecar to the MCP server.
+
+Only the **Streamable HTTP** transport is supported, exposed on a single endpoint `/mcp` (`POST`, `GET`, `DELETE`). Sessions are identified by the `Mcp-Session-Id` header — Selenosis is stateless and derives the target pod from it.
+
+### Create an MCP session
+
+A session is created by the standard MCP `initialize` call: a `POST /mcp` **without** an `Mcp-Session-Id` header. Selenosis requires `browser` and `version` query parameters to know which browser to start:
+
+`POST /mcp?browser=<name>&version=<version>`
+
+Selenosis creates a `Browser` resource, waits for the pod to become ready, and forwards the `initialize` request to the MCP server. The pod-derived session id is returned in the `Mcp-Session-Id` **response header**; clients send it back on every subsequent request.
+
+Additional query parameters are parsed as [`selenosis:options`](#selenosisoptions) (same as the Playwright endpoint).
+
+```bash
+curl -isS -X POST 'http://{selenosis_host:port}/mcp?browser=playwright-mcp&version=0.0.75' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"example","version":"1.0.0"}}}'
+# the response includes header: Mcp-Session-Id: <pod-uuid>
+```
+
+### Proxying MCP traffic
+
+Once initialized, send the returned `Mcp-Session-Id` header on every request. Selenosis routes by that header to the correct pod and proxies to the sidecar `/mcp`.
+
+```bash
+# Client request
+curl -sS -X POST http://{selenosis_host:port}/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Mcp-Session-Id: <pod-uuid>' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+# Server-initiated message stream
+curl -sS http://{selenosis_host:port}/mcp \
+  -H 'Mcp-Session-Id: <pod-uuid>'
+```
+
+### Terminating an MCP session
+
+```bash
+curl -sS -X DELETE http://{selenosis_host:port}/mcp \
+  -H 'Mcp-Session-Id: <pod-uuid>'
+```
+
+This ends the MCP session and tears down the browser pod.
+
+### Session expiry and reconnection
+
+If a browser pod is torn down (for example after the idle timeout), a later `POST`/`GET`/`DELETE /mcp` carrying the now-stale `Mcp-Session-Id` returns **`404`**. Per the MCP spec, a `404` on a request that includes a session id signals that the session no longer exists, so a spec-compliant client drops the id and performs a fresh `initialize` — which transparently starts a new browser pod. A missing `Mcp-Session-Id` header on a non-initialize request returns `400`, as does a malformed (non-UUID) id.
+
+### MCP Playwright example
+
+```javascript
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+// Point the transport at /mcp with the desired browser/version.
+// The SDK performs `initialize`, captures the Mcp-Session-Id response header,
+// and replays it on every subsequent request automatically.
+const url = new URL('http://{selenosis_host:port}/mcp?browser=playwright-mcp&version=0.0.75');
+const transport = new StreamableHTTPClientTransport(url);
+const client = new Client({ name: 'example', version: '1.0.0' });
+await client.connect(transport);
+
+const tools = await client.listTools();
+await client.callTool({
+  name: 'browser_navigate',
+  arguments: { url: 'https://example.com' }
+});
+
+await client.close(); // sends DELETE /mcp and tears down the pod
+```
+
+### MCP Selenium example
+
+```javascript
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const url = new URL('http://{selenosis_host:port}/mcp?browser=playwright-mcp&version=0.0.75');
+const transport = new StreamableHTTPClientTransport(url);
+const client = new Client({ name: 'example', version: '1.0.0' });
+await client.connect(transport);
+
+const tools = await client.listTools();
+await client.callTool({
+  name: 'navigate',
+  arguments: { url: 'https://example.com' }
+});
+
+await client.close();
+```
+
 ## Basic Authentication in Selenosis
 
 Selenosis supports optional HTTP Basic Authentication for protecting its public API endpoints.
@@ -407,15 +527,17 @@ The project is built and packaged entirely via Docker. Local Go installation is 
 
 The build process is controlled via the following Makefile variables:
 
-Variable	Description
-- BINARY_NAME	Name of the produced binary (selenosis).
-- REGISTRY	Docker registry prefix (default: localhost:5000).
-- IMAGE_NAME	Full image name (<registry>/selenosis).
-- VERSION	Image version/tag (default: develop).
-- PLATFORM	Target platform (default: linux/amd64).
-- CONTAINER_TOOL docker cmd
+| Variable         | Description                                                  |
+|------------------|--------------------------------------------------------------|
+| `BINARY_NAME`    | Name of the produced binary (fixed: `selenosis`)            |
+| `REGISTRY`       | Docker registry prefix (default: `localhost:5000`)           |
+| `IMAGE_NAME`     | Full image name, derived as `$(REGISTRY)/$(BINARY_NAME)`     |
+| `VERSION`        | Image version/tag (default: `develop`)                       |
+| `EXTRA_TAGS`     | Additional `-t` tags passed to `docker-push` (default: none) |
+| `PLATFORM`       | Target platform (default: `linux/amd64`)                     |
+| `CONTAINER_TOOL` | Container build tool (default: `docker`)                     |
 
-REGISTRY, VERSION is expected to be provided externally, which allows the same Makefile to be used locally and in CI.
+`REGISTRY` and `VERSION` are expected to be provided externally, which allows the same Makefile to be used locally and in CI.
 
 ## Deployment
 

--- a/cmd/selenosis/main.go
+++ b/cmd/selenosis/main.go
@@ -26,10 +26,15 @@ func main() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	log := zerolog.New(os.Stdout).With().Timestamp().Logger()
 
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	cfg, authStore, listenAddr, apiURL, err := loadConfig()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to load configuration")
 	}
+
+	go auth.Watch(ctx, authStore)
 
 	clientConfig := client.ClientConfig{
 		BaseURL:    apiURL,
@@ -65,24 +70,7 @@ func main() {
 		return http.HandlerFunc(fn)
 	})
 
-	router.Use(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-
-			ctx := req.Context()
-			if authStore != nil {
-				user, pass, ok := req.BasicAuth()
-				if !ok || !authStore.Authenticate(user, pass) {
-					log.Error().Msg("request authentication failed")
-					http.Error(rw, "authentication failed", http.StatusUnauthorized)
-					return
-				}
-				req.URL.User = nil
-				ctx = auth.WithOwner(ctx, auth.Owner{Name: user})
-			}
-
-			next.ServeHTTP(rw, req.WithContext(ctx))
-		})
-	})
+	router.Use(basicAuthMiddleware(authStore, log))
 
 	selenium := chi.NewRouter()
 
@@ -116,16 +104,33 @@ func main() {
 		}
 	}()
 
-	stopCh := make(chan os.Signal, 1)
-	signal.Notify(stopCh, syscall.SIGINT, syscall.SIGTERM)
-	<-stopCh
+	<-ctx.Done()
+	stop()
 	log.Info().Msg("Shutting down HTTP server...")
 
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer shutdownCancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		log.Err(err).Msg("HTTP server shutdown error")
 		os.Exit(1)
+	}
+}
+
+func basicAuthMiddleware(authStore *auth.AuthStore, log zerolog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if authStore != nil {
+				user, pass, ok := req.BasicAuth()
+				if !ok || !authStore.Authenticate(user, pass) {
+					log.Error().Msg("request authentication failed")
+					http.Error(rw, "authentication failed", http.StatusUnauthorized)
+					return
+				}
+				req.URL.User = nil
+				req = req.WithContext(auth.WithOwner(req.Context(), auth.Owner{Name: user}))
+			}
+			next.ServeHTTP(rw, req)
+		})
 	}
 }
 

--- a/cmd/selenosis/main.go
+++ b/cmd/selenosis/main.go
@@ -34,7 +34,9 @@ func main() {
 		log.Fatal().Err(err).Msg("failed to load configuration")
 	}
 
-	go auth.Watch(ctx, authStore)
+	if authStore != nil {
+		go auth.Watch(ctx, authStore)
+	}
 
 	clientConfig := client.ClientConfig{
 		BaseURL:    apiURL,
@@ -84,6 +86,14 @@ func main() {
 	router.Mount("/wd/hub", selenium)
 
 	router.Get("/playwright/{name}/{version}", svc.Playwright)
+
+	mcp := chi.NewRouter()
+
+	mcp.Post("/", svc.McpHandler)
+	mcp.Get("/", svc.McpHandler)
+	mcp.Delete("/", svc.McpHandler)
+
+	router.Mount("/mcp", mcp)
 
 	router.Route("/selenosis/v1/sessions/{sessionId}", func(r chi.Router) {
 		r.Route("/proxy", func(r chi.Router) {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	dario.cat/mergo v1.0.2
 	github.com/alcounit/browser-controller v0.0.6
 	github.com/alcounit/browser-service v0.0.6
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	dario.cat/mergo v1.0.2
-	github.com/alcounit/browser-controller v0.0.6
-	github.com/alcounit/browser-service v0.0.6
+	github.com/alcounit/browser-controller v0.0.8
+	github.com/alcounit/browser-service v0.0.7
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
-github.com/alcounit/browser-controller v0.0.6 h1:EJ7WAgxIwrn4DTpNVET/L67+WhRQDduSuHAMxcPw4gg=
-github.com/alcounit/browser-controller v0.0.6/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
-github.com/alcounit/browser-service v0.0.6 h1:cDfYNPIOSzMKWgWOBwbhg3UH8JtL4aNj5vrj5uxJCd0=
-github.com/alcounit/browser-service v0.0.6/go.mod h1:el3dWyMLDd/bT2vyC6Zcsl8P5u9QmZmaTf9RFp7O1+k=
+github.com/alcounit/browser-controller v0.0.8 h1:hauzkisDiUsGoIKUoQqvBmi4/MrixzGp55PnZIUA6rY=
+github.com/alcounit/browser-controller v0.0.8/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
+github.com/alcounit/browser-service v0.0.7 h1:Pv33j3QrtjZaa4QxoohzCGn1urJ20kiMLgDwKeg1y1Q=
+github.com/alcounit/browser-service v0.0.7/go.mod h1:Oozpap9DWLAu2ViuJua5Q9KHXziVZUUFhacC//SVlXw=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,9 +1,15 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sync"
+
+	logctx "github.com/alcounit/browser-controller/pkg/log"
+	"github.com/fsnotify/fsnotify"
 )
 
 type User struct {
@@ -12,23 +18,27 @@ type User struct {
 }
 
 type AuthStore struct {
+	mu    sync.RWMutex
 	users map[string]string
+	path  string
 }
 
 func (s *AuthStore) Authenticate(user, pass string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	expected, exists := s.users[user]
 	return exists && pass == expected
 }
 
-func LoadFromJSONFile(path string) (*AuthStore, error) {
-	data, err := os.ReadFile(path)
+func reload(s *AuthStore) error {
+	data, err := os.ReadFile(s.path)
 	if err != nil {
-		return nil, fmt.Errorf("read auth file: %w", err)
+		return fmt.Errorf("read auth file: %w", err)
 	}
 
 	var list []User
 	if err := json.Unmarshal(data, &list); err != nil {
-		return nil, fmt.Errorf("parse auth file: %w", err)
+		return fmt.Errorf("parse auth file: %w", err)
 	}
 
 	users := make(map[string]string, len(list))
@@ -40,8 +50,64 @@ func LoadFromJSONFile(path string) (*AuthStore, error) {
 	}
 
 	if len(users) == 0 {
-		return nil, fmt.Errorf("auth file is empty")
+		return fmt.Errorf("auth file is empty")
 	}
 
-	return &AuthStore{users: users}, nil
+	s.mu.Lock()
+	s.users = users
+	s.mu.Unlock()
+	return nil
+}
+
+func Watch(ctx context.Context, as *AuthStore) {
+	log := logctx.FromContext(ctx)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Error().Err(err).Msg("auth watcher: failed to create")
+		return
+	}
+	defer watcher.Close()
+
+	dir := filepath.Dir(as.path)
+	if err := watcher.Add(dir); err != nil {
+		log.Error().Err(err).Str("dir", dir).Msg("auth watcher: failed to watch directory")
+		return
+	}
+
+	base := filepath.Base(as.path)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			name := filepath.Base(event.Name)
+			k8sRotation := name == "..data" && event.Has(fsnotify.Create)
+			directWrite := name == base && (event.Has(fsnotify.Write) || event.Has(fsnotify.Create))
+			if k8sRotation || directWrite {
+				if err := reload(as); err != nil {
+					log.Error().Err(err).Msg("auth watcher: reload failed")
+				} else {
+					log.Info().Msg("auth file reloaded")
+				}
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Error().Err(err).Msg("auth watcher error")
+		}
+	}
+}
+
+func LoadFromJSONFile(path string) (*AuthStore, error) {
+	store := &AuthStore{path: path}
+	if err := reload(store); err != nil {
+		return nil, err
+	}
+	return store, nil
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,10 +1,13 @@
 package auth
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func writeTempFile(t *testing.T, content string) string {
@@ -95,5 +98,181 @@ func TestLoadFromJSONFileOnlyEmptyUsers(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "auth file is empty") {
 		t.Fatalf("expected empty auth error, got %v", err)
+	}
+}
+
+func TestReloadUpdatesCredentials(t *testing.T) {
+	path := writeTempFile(t, `[{"user":"alice","pass":"old"}]`)
+	store, err := LoadFromJSONFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if err := os.WriteFile(path, []byte(`[{"user":"alice","pass":"new"}]`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := reload(store); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	if store.Authenticate("alice", "old") {
+		t.Fatal("old password should no longer work")
+	}
+	if !store.Authenticate("alice", "new") {
+		t.Fatal("new password should work")
+	}
+}
+
+func TestReloadPreservesCredentialsOnError(t *testing.T) {
+	path := writeTempFile(t, `[{"user":"alice","pass":"ok"}]`)
+	store, err := LoadFromJSONFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if err := os.WriteFile(path, []byte(`{broken`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := reload(store); err == nil {
+		t.Fatal("expected error on bad JSON")
+	}
+
+	if !store.Authenticate("alice", "ok") {
+		t.Fatal("credentials should be preserved after failed reload")
+	}
+}
+
+func TestReloadConcurrent(t *testing.T) {
+	path := writeTempFile(t, `[{"user":"u","pass":"p"}]`)
+	store, err := LoadFromJSONFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			store.Authenticate("u", "p")
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = reload(store)
+		}()
+	}
+	wg.Wait()
+}
+
+func pollUntil(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+func TestWatchDirectWrite(t *testing.T) {
+	path := writeTempFile(t, `[{"user":"alice","pass":"old"}]`)
+	store, err := LoadFromJSONFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go Watch(ctx, store)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if err := os.WriteFile(path, []byte(`[{"user":"alice","pass":"new"}]`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if !pollUntil(t, 2*time.Second, func() bool { return store.Authenticate("alice", "new") }) {
+		t.Fatal("store was not reloaded after direct file write")
+	}
+}
+
+func TestWatchKubernetesStyleRotation(t *testing.T) {
+	// mirrors how kubelet mounts Secrets:
+	// mountDir/
+	//   ..data/auth.json   <- actual file
+	//   auth.json          -> ..data/auth.json (symlink)
+	mountDir := t.TempDir()
+	dataDir := filepath.Join(mountDir, "..data")
+	if err := os.Mkdir(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	dataFile := filepath.Join(dataDir, "auth.json")
+	if err := os.WriteFile(dataFile, []byte(`[{"user":"alice","pass":"old"}]`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	authPath := filepath.Join(mountDir, "auth.json")
+	if err := os.Symlink(dataFile, authPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	store, err := LoadFromJSONFile(authPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go Watch(ctx, store)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// simulate kubelet atomic swap: write new data dir, rename over ..data
+	newDataDir := filepath.Join(mountDir, "..data_tmp")
+	if err := os.Mkdir(newDataDir, 0o755); err != nil {
+		t.Fatalf("mkdir tmp: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(newDataDir, "auth.json"), []byte(`[{"user":"alice","pass":"new"}]`), 0o600); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	if err := os.RemoveAll(dataDir); err != nil {
+		t.Fatalf("remove old datadir: %v", err)
+	}
+	if err := os.Rename(newDataDir, dataDir); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	if !pollUntil(t, 2*time.Second, func() bool { return store.Authenticate("alice", "new") }) {
+		t.Fatal("store was not reloaded after Kubernetes-style Secret rotation")
+	}
+}
+
+func TestWatchStopsOnContextCancel(t *testing.T) {
+	path := writeTempFile(t, `[{"user":"u","pass":"p"}]`)
+	store, err := LoadFromJSONFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		Watch(ctx, store)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Watch did not stop after context cancellation")
 	}
 }

--- a/pkg/jsonrpc/jsonrpc.go
+++ b/pkg/jsonrpc/jsonrpc.go
@@ -1,0 +1,29 @@
+package jsonrpc
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// JSON-RPC 2.0 error codes, see https://www.jsonrpc.org/specification#error_object :
+// -32700/-32600/-32603 are reserved (parse error / invalid request / internal error);
+// -32000..-32099 are reserved for server-defined errors. SessionNotFound (-32001) matches
+// the MCP Streamable HTTP transport in the official SDK
+// (https://github.com/modelcontextprotocol/typescript-sdk).
+const (
+	InvalidRequest  = -32600
+	InvalidParams   = -32602
+	InternalError   = -32603
+	SessionNotFound = -32001
+)
+
+// WriteError writes an MCP (JSON-RPC 2.0) error response with the given HTTP status and code.
+func WriteError(rw http.ResponseWriter, status, code int, message string) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(status)
+	json.NewEncoder(rw).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      nil,
+		"error":   map[string]any{"code": code, "message": message},
+	})
+}

--- a/pkg/jsonrpc/jsonrpc_test.go
+++ b/pkg/jsonrpc/jsonrpc_test.go
@@ -1,0 +1,60 @@
+package jsonrpc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteError(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		code    int
+		message string
+	}{
+		{"invalid params", http.StatusBadRequest, InvalidParams, "Bad Request: missing params"},
+		{"invalid request", http.StatusBadRequest, InvalidRequest, "Invalid Request: already initialized"},
+		{"session not found", http.StatusNotFound, SessionNotFound, "Session not found"},
+		{"internal error", http.StatusInternalServerError, InternalError, "Internal error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := httptest.NewRecorder()
+			WriteError(rw, tt.status, tt.code, tt.message)
+
+			if rw.Code != tt.status {
+				t.Fatalf("expected status %d, got %d", tt.status, rw.Code)
+			}
+			if ct := rw.Header().Get("Content-Type"); ct != "application/json" {
+				t.Fatalf("expected Content-Type application/json, got %q", ct)
+			}
+
+			var body struct {
+				JSONRPC string `json:"jsonrpc"`
+				ID      any    `json:"id"`
+				Error   struct {
+					Code    int    `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+				t.Fatalf("failed to decode body %q: %v", rw.Body.String(), err)
+			}
+			if body.JSONRPC != "2.0" {
+				t.Fatalf("expected jsonrpc 2.0, got %q", body.JSONRPC)
+			}
+			if body.ID != nil {
+				t.Fatalf("expected id null, got %v", body.ID)
+			}
+			if body.Error.Code != tt.code {
+				t.Fatalf("expected code %d, got %d", tt.code, body.Error.Code)
+			}
+			if body.Error.Message != tt.message {
+				t.Fatalf("expected message %q, got %q", tt.message, body.Error.Message)
+			}
+		})
+	}
+}

--- a/pkg/proxy/http_proxy.go
+++ b/pkg/proxy/http_proxy.go
@@ -24,33 +24,34 @@ type ResponseModifier func(*http.Response) error
 type ErrorHandler func(w http.ResponseWriter, r *http.Request, err error)
 
 type HTTPReverseProxy struct {
-	rp *httputil.ReverseProxy
+	rp              *httputil.ReverseProxy
+	requestModifier RequestModifier
 }
 
 type HTTPReverseProxyOptions func(*HTTPReverseProxy)
 
 func WithTransport(transport http.RoundTripper) HTTPReverseProxyOptions {
-	return HTTPReverseProxyOptions(func(p *HTTPReverseProxy) {
+	return func(p *HTTPReverseProxy) {
 		p.rp.Transport = transport
-	})
+	}
 }
 
 func WithRequestModifier(modifier RequestModifier) HTTPReverseProxyOptions {
-	return HTTPReverseProxyOptions(func(p *HTTPReverseProxy) {
-		p.rp.Director = modifier
-	})
+	return func(p *HTTPReverseProxy) {
+		p.requestModifier = modifier
+	}
 }
 
-func WithResponseModifier(modifier func(*http.Response) error) HTTPReverseProxyOptions {
-	return HTTPReverseProxyOptions(func(p *HTTPReverseProxy) {
+func WithResponseModifier(modifier ResponseModifier) HTTPReverseProxyOptions {
+	return func(p *HTTPReverseProxy) {
 		p.rp.ModifyResponse = modifier
-	})
+	}
 }
 
 func WithErrorHandler(errHandler ErrorHandler) HTTPReverseProxyOptions {
-	return HTTPReverseProxyOptions(func(p *HTTPReverseProxy) {
+	return func(p *HTTPReverseProxy) {
 		p.rp.ErrorHandler = errHandler
-	})
+	}
 }
 
 func NewHTTPReverseProxy(opts ...HTTPReverseProxyOptions) *HTTPReverseProxy {
@@ -66,18 +67,22 @@ func NewHTTPReverseProxy(opts ...HTTPReverseProxyOptions) *HTTPReverseProxy {
 		opt(&proxy)
 	}
 
+	proxy.rp.Rewrite = func(pr *httputil.ProxyRequest) {
+		pr.SetXForwarded()
+
+		if proxy.requestModifier != nil {
+			proxy.requestModifier(pr.Out)
+			return
+		}
+
+		pr.Out.URL.Scheme = pr.In.URL.Scheme
+		pr.Out.URL.Host = pr.In.URL.Host
+		pr.Out.URL.Path = pr.In.URL.Path
+	}
+
 	return &proxy
 }
 
 func (p *HTTPReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-
-	if p.rp.Director == nil {
-		p.rp.Director = func(r *http.Request) {
-			r.URL.Scheme = req.URL.Scheme
-			r.URL.Host = req.URL.Host
-			r.URL.Path = req.URL.Path
-		}
-	}
-
 	p.rp.ServeHTTP(rw, req)
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -80,12 +80,12 @@ func TestWithResponseModifier(t *testing.T) {
 		}, nil
 	})
 
-	rp := NewHTTPReverseProxy(WithResponseModifier(respMod), WithTransport(rt))
-	rp.rp.Director = func(r *http.Request) {
+	modifier := func(r *http.Request) {
 		u, _ := url.Parse("http://example.com/")
 		r.URL = u
 		r.Host = u.Host
 	}
+	rp := NewHTTPReverseProxy(WithResponseModifier(respMod), WithRequestModifier(modifier), WithTransport(rt))
 
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
@@ -124,7 +124,7 @@ func TestWithErrorHandler(t *testing.T) {
 	}
 }
 
-func TestServeHTTPWithDefaultDirector(t *testing.T) {
+func TestServeHTTPWithDefaultRewrite(t *testing.T) {
 	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.Path != "/test" {
 			t.Errorf("expected path /test, got %s", req.URL.Path)
@@ -147,9 +147,9 @@ func TestServeHTTPWithDefaultDirector(t *testing.T) {
 	}
 }
 
-func TestServeHTTPWithCustomDirector(t *testing.T) {
+func TestServeHTTPWithCustomRequestModifier(t *testing.T) {
 	backendURL, _ := url.Parse("http://example.com")
-	customDirector := func(r *http.Request) {
+	customModifier := func(r *http.Request) {
 		r.URL = backendURL
 		r.Host = backendURL.Host
 	}
@@ -161,7 +161,7 @@ func TestServeHTTPWithCustomDirector(t *testing.T) {
 			Header:     make(http.Header),
 		}, nil
 	})
-	rp := NewHTTPReverseProxy(WithRequestModifier(customDirector), WithTransport(rt))
+	rp := NewHTTPReverseProxy(WithRequestModifier(customModifier), WithTransport(rt))
 	req := httptest.NewRequest("GET", "http://original/", nil)
 	w := httptest.NewRecorder()
 	rp.ServeHTTP(w, req)
@@ -171,33 +171,31 @@ func TestServeHTTPWithCustomDirector(t *testing.T) {
 	}
 }
 
-func TestNewHTTPReverseProxyWithNoOpts(t *testing.T) {
-	rp := NewHTTPReverseProxy()
-	if rp.rp.Transport != DefaultTransport {
-		t.Error("expected default transport")
-	}
-}
-
-func TestServeHTTPWithDirectorAlreadySet(t *testing.T) {
-	backendURL, _ := url.Parse("http://example.com")
-	rp := NewHTTPReverseProxy()
-	rp.rp.Director = func(r *http.Request) {
-		r.URL = backendURL
-		r.Host = backendURL.Host
-	}
-	rp.rp.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+func TestServeHTTPSetsXForwardedFor(t *testing.T) {
+	var gotFor string
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotFor = req.Header.Get("X-Forwarded-For")
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewBufferString("director-already-set")),
+			Body:       io.NopCloser(bytes.NewBufferString("ok")),
 			Header:     make(http.Header),
 		}, nil
 	})
 
-	req := httptest.NewRequest("GET", "http://example/", nil)
+	rp := NewHTTPReverseProxy(WithTransport(rt))
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	req.RemoteAddr = "203.0.113.7:4321"
 	w := httptest.NewRecorder()
 	rp.ServeHTTP(w, req)
 
-	if w.Body.String() != "director-already-set" {
-		t.Errorf("expected director-already-set, got %s", w.Body.String())
+	if gotFor != "203.0.113.7" {
+		t.Errorf("expected X-Forwarded-For 203.0.113.7, got %q", gotFor)
+	}
+}
+
+func TestNewHTTPReverseProxyWithNoOpts(t *testing.T) {
+	rp := NewHTTPReverseProxy()
+	if rp.rp.Transport != DefaultTransport {
+		t.Error("expected default transport")
 	}
 }

--- a/pkg/proxy/ws_proxy.go
+++ b/pkg/proxy/ws_proxy.go
@@ -128,7 +128,9 @@ func (p *WSProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	clientConn, err := p.Upgrader.Upgrade(w, r, upgradeHeaders)
 	if err != nil {
 		log.Error().Err(err).Msg("client websocket upgrade failed")
-		http.Error(w, fmt.Sprintf("Upgrade client connection failed: %s", err.Error()), http.StatusInternalServerError)
+		if err = upstreamConn.Close(); err != nil {
+			log.Error().Err(err).Msg("failed to close upstream connection")
+		}
 		return
 	}
 

--- a/pkg/proxy/ws_proxy_test.go
+++ b/pkg/proxy/ws_proxy_test.go
@@ -390,6 +390,52 @@ func TestWSProxyServeHTTPUpgradeErrorWithRetry(t *testing.T) {
 	<-done
 }
 
+func TestWSProxyServeHTTPClosesUpstreamOnUpgradeFailure(t *testing.T) {
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close() })
+	t.Cleanup(func() { _ = upServer.Close() })
+
+	p := NewWebSocketReverseProxy(func(r *http.Request) (*url.URL, error) {
+		return url.Parse("ws://upstream.test/ws")
+	})
+	p.Dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return upClient, nil
+	}
+
+	upstreamClosed := make(chan struct{})
+	go func() {
+		if err := writeHandshakeResponse(upServer); err != nil {
+			return
+		}
+		// Blocks until the proxy closes the upstream connection after the
+		// client upgrade fails; an open read here would mean the conn leaked.
+		buf := make([]byte, 1)
+		_, _ = upServer.Read(buf)
+		close(upstreamClosed)
+	}()
+
+	// httptest.NewRecorder does not implement http.Hijacker, so the client
+	// upgrade fails after the upstream connection is already established.
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/ws", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Sec-WebSocket-Version", "13")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	rw := httptest.NewRecorder()
+
+	p.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rw.Code)
+	}
+
+	select {
+	case <-upstreamClosed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("upstream connection was not closed after client upgrade failure")
+	}
+}
+
 func TestWSProxyServeHTTPSuccess(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
 	t.Cleanup(func() { _ = clientConn.Close() })

--- a/pkg/selenium/error.go
+++ b/pkg/selenium/error.go
@@ -1,7 +1,9 @@
 package selenium
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 )
 
 type SeleniumError struct {
@@ -9,6 +11,12 @@ type SeleniumError struct {
 		Name    string `json:"error"`
 		Message string `json:"message"`
 	} `json:"value"`
+}
+
+func WriteError(rw http.ResponseWriter, status int, err *SeleniumError) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(status)
+	json.NewEncoder(rw).Encode(err)
 }
 
 func ErrSessionNotCreated(err error) *SeleniumError {

--- a/pkg/selenium/error_test.go
+++ b/pkg/selenium/error_test.go
@@ -1,7 +1,10 @@
 package selenium
 
 import (
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -45,5 +48,28 @@ func TestErrorDirect(t *testing.T) {
 	}
 	if !strings.Contains(se.Value.Message, "direct cause") {
 		t.Errorf("message should contain direct cause, got %s", se.Value.Message)
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	rw := httptest.NewRecorder()
+	WriteError(rw, http.StatusBadRequest, ErrSessionNotCreated(errors.New("boom")))
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rw.Code)
+	}
+	if ct := rw.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var body SeleniumError
+	if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode body %q: %v", rw.Body.String(), err)
+	}
+	if body.Value.Name != "session not created" {
+		t.Fatalf("expected error name 'session not created', got %q", body.Value.Name)
+	}
+	if !strings.Contains(body.Value.Message, "boom") {
+		t.Fatalf("expected message to contain root cause, got %q", body.Value.Message)
 	}
 }

--- a/service/errors.go
+++ b/service/errors.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"errors"
+	"net"
+	"net/http"
+
+	"github.com/alcounit/selenosis/v2/pkg/jsonrpc"
+	"github.com/alcounit/selenosis/v2/pkg/proxy"
+	"github.com/alcounit/selenosis/v2/pkg/selenium"
+	"github.com/rs/zerolog"
+)
+
+func isUpstreamUnreachable(err error) bool {
+	var opErr *net.OpError
+	return errors.As(err, &opErr) && opErr.Op == "dial"
+}
+
+func createSessionProxyErrorHandler(log zerolog.Logger, ip string) proxy.ErrorHandler {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		log.Err(err).Str("ip", ip).Msg("session create proxy error")
+		writeErrorResponse(w, http.StatusInternalServerError, selenium.ErrSessionNotCreated(err))
+	}
+}
+
+func sessionProxyErrorHandler(log zerolog.Logger, sessionId string) proxy.ErrorHandler {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		if isUpstreamUnreachable(err) {
+			log.Warn().Err(err).Str("sessionId", sessionId).Msg("session pod unreachable")
+			writeErrorResponse(w, http.StatusNotFound, selenium.ErrInvalidSessionId(err))
+			return
+		}
+		log.Err(err).Str("sessionId", sessionId).Msg("session proxy error")
+		writeErrorResponse(w, http.StatusInternalServerError, selenium.ErrUnknown(err))
+	}
+}
+
+func routeHTTPProxyErrorHandler(log zerolog.Logger, sessionId string) proxy.ErrorHandler {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		if isUpstreamUnreachable(err) {
+			log.Warn().Err(err).Str("sessionId", sessionId).Msg("pod unreachable")
+			http.Error(w, "session not found", http.StatusNotFound)
+			return
+		}
+		log.Err(err).Str("sessionId", sessionId).Msg("http proxy error")
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}
+}
+
+func mcpInitProxyErrorHandler(log zerolog.Logger, ip string) proxy.ErrorHandler {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		log.Err(err).Str("ip", ip).Msg("mcp initialize proxy error")
+		jsonrpc.WriteError(w, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error")
+	}
+}
+
+func mcpProxyErrorHandler(log zerolog.Logger, ip string) proxy.ErrorHandler {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		if isUpstreamUnreachable(err) {
+			log.Warn().Err(err).Str("ip", ip).Msg("mcp upstream unreachable, session expired")
+			jsonrpc.WriteError(w, http.StatusNotFound, jsonrpc.SessionNotFound, "Session not found")
+			return
+		}
+		log.Err(err).Str("ip", ip).Msg("mcp proxy error")
+		jsonrpc.WriteError(w, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error")
+	}
+}
+
+type browserError struct {
+	kind errorKind
+	err  error
+}
+
+func writeCreateSessionWaitError(rw http.ResponseWriter, waitErr *browserError) {
+	switch waitErr.kind {
+	case browserCreate:
+		writeErrorResponse(rw, http.StatusInternalServerError, selenium.Error("failed to create browser", waitErr.err))
+	case browserEventsStart:
+		writeErrorResponse(rw, http.StatusInternalServerError, selenium.Error("failed to start browser event stream", waitErr.err))
+	case browserStreamClosed:
+		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(ErrInternal))
+	case browserFailed:
+		writeErrorResponse(rw, http.StatusInternalServerError, selenium.Error("browser failed to start", ErrInternal))
+	case browserStreamError:
+		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(waitErr.err))
+	case browserContextDone:
+		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(ErrInternal))
+	default:
+		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(ErrInternal))
+	}
+}
+
+func writePlaywrightWaitError(rw http.ResponseWriter, waitErr *browserError) {
+	switch waitErr.kind {
+	case browserCreate:
+		http.Error(rw, "failed to create browser resource", http.StatusInternalServerError)
+	case browserEventsStart:
+		http.Error(rw, "failed to start browser event stream", http.StatusInternalServerError)
+	case browserStreamClosed:
+		http.Error(rw, "browser event stream closed unexpectedly", http.StatusInternalServerError)
+	case browserFailed:
+		http.Error(rw, "browser failed to start", http.StatusInternalServerError)
+	case browserStreamError:
+		http.Error(rw, "browser event stream error", http.StatusInternalServerError)
+	case browserContextDone:
+		http.Error(rw, "context cancelled, stopping browser event stream", http.StatusInternalServerError)
+	default:
+		http.Error(rw, "internal server error", http.StatusInternalServerError)
+	}
+}
+
+func writeMcpWaitError(rw http.ResponseWriter, waitErr *browserError) {
+	switch waitErr.kind {
+	case browserCreate:
+		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error: failed to create browser resource")
+	case browserEventsStart:
+		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error: failed to start browser event stream")
+	case browserStreamClosed:
+		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error: browser event stream closed unexpectedly")
+	case browserFailed:
+		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error: browser failed to start")
+	case browserStreamError:
+		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error: browser event stream error")
+	case browserContextDone:
+		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error: context cancelled, stopping browser event stream")
+	default:
+		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error")
+	}
+}

--- a/service/errors_test.go
+++ b/service/errors_test.go
@@ -1,0 +1,160 @@
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func dialErr() error {
+	return &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+}
+
+func assertMcpError(t *testing.T, rw *httptest.ResponseRecorder, wantStatus, wantCode int) {
+	t.Helper()
+	if rw.Code != wantStatus {
+		t.Fatalf("expected status %d, got %d", wantStatus, rw.Code)
+	}
+	if ct := rw.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", ct)
+	}
+	var body struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      any    `json:"id"`
+		Error   struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode JSON-RPC error body %q: %v", rw.Body.String(), err)
+	}
+	if body.JSONRPC != "2.0" {
+		t.Fatalf("expected jsonrpc 2.0, got %q", body.JSONRPC)
+	}
+	if body.ID != nil {
+		t.Fatalf("expected id null, got %v", body.ID)
+	}
+	if body.Error.Code != wantCode {
+		t.Fatalf("expected error code %d, got %d", wantCode, body.Error.Code)
+	}
+	if body.Error.Message == "" {
+		t.Fatal("expected non-empty error message")
+	}
+}
+
+func TestIsUpstreamUnreachable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"dial op error", &net.OpError{Op: "dial", Err: errors.New("refused")}, true},
+		{"wrapped dial op error", fmt.Errorf("proxy: %w", &net.OpError{Op: "dial"}), true},
+		{"read op error", &net.OpError{Op: "read", Err: errors.New("reset")}, false},
+		{"write op error", &net.OpError{Op: "write", Err: errors.New("broken pipe")}, false},
+		{"generic error", errors.New("boom"), false},
+		{"nil error", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUpstreamUnreachable(tt.err); got != tt.want {
+				t.Fatalf("isUpstreamUnreachable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateSessionProxyErrorHandler(t *testing.T) {
+	h := createSessionProxyErrorHandler(zerolog.Nop(), "10.0.0.1")
+	rw := httptest.NewRecorder()
+	h(rw, httptest.NewRequest(http.MethodPost, "/", nil), errors.New("boom"))
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "session not created") {
+		t.Fatalf("expected selenium session not created error, got %s", rw.Body.String())
+	}
+}
+
+func TestSessionProxyErrorHandlerUnreachable(t *testing.T) {
+	h := sessionProxyErrorHandler(zerolog.Nop(), "sid")
+	rw := httptest.NewRecorder()
+	h(rw, httptest.NewRequest(http.MethodGet, "/", nil), dialErr())
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "invalid session id") {
+		t.Fatalf("expected invalid session id error, got %s", rw.Body.String())
+	}
+}
+
+func TestSessionProxyErrorHandlerGeneric(t *testing.T) {
+	h := sessionProxyErrorHandler(zerolog.Nop(), "sid")
+	rw := httptest.NewRecorder()
+	h(rw, httptest.NewRequest(http.MethodGet, "/", nil), errors.New("boom"))
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "unknown error") {
+		t.Fatalf("expected unknown error, got %s", rw.Body.String())
+	}
+}
+
+func TestRouteHTTPProxyErrorHandlerUnreachable(t *testing.T) {
+	h := routeHTTPProxyErrorHandler(zerolog.Nop(), "sid")
+	rw := httptest.NewRecorder()
+	h(rw, httptest.NewRequest(http.MethodGet, "/", nil), dialErr())
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "session not found") {
+		t.Fatalf("expected session not found, got %s", rw.Body.String())
+	}
+}
+
+func TestRouteHTTPProxyErrorHandlerGeneric(t *testing.T) {
+	h := routeHTTPProxyErrorHandler(zerolog.Nop(), "sid")
+	rw := httptest.NewRecorder()
+	h(rw, httptest.NewRequest(http.MethodGet, "/", nil), errors.New("boom"))
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rw.Code)
+	}
+}
+
+func TestMcpInitProxyErrorHandler(t *testing.T) {
+	h := mcpInitProxyErrorHandler(zerolog.Nop(), "10.0.0.1")
+	rw := httptest.NewRecorder()
+	h(rw, httptest.NewRequest(http.MethodPost, "/", nil), dialErr())
+
+	assertMcpError(t, rw, http.StatusInternalServerError, -32603)
+}
+
+func TestMcpProxyErrorHandlerUnreachable(t *testing.T) {
+	h := mcpProxyErrorHandler(zerolog.Nop(), "10.0.0.1")
+	rw := httptest.NewRecorder()
+	h(rw, httptest.NewRequest(http.MethodPost, "/", nil), dialErr())
+
+	assertMcpError(t, rw, http.StatusNotFound, -32001)
+}
+
+func TestMcpProxyErrorHandlerGeneric(t *testing.T) {
+	h := mcpProxyErrorHandler(zerolog.Nop(), "10.0.0.1")
+	rw := httptest.NewRecorder()
+	h(rw, httptest.NewRequest(http.MethodPost, "/", nil), errors.New("boom"))
+
+	assertMcpError(t, rw, http.StatusInternalServerError, -32603)
+}

--- a/service/service.go
+++ b/service/service.go
@@ -19,6 +19,7 @@ import (
 	browserclient "github.com/alcounit/browser-service/pkg/client/browser"
 	"github.com/alcounit/selenosis/v2/pkg/auth"
 	"github.com/alcounit/selenosis/v2/pkg/ipuuid"
+	"github.com/alcounit/selenosis/v2/pkg/jsonrpc"
 	"github.com/alcounit/selenosis/v2/pkg/proxy"
 	"github.com/alcounit/selenosis/v2/pkg/selenium"
 	"github.com/go-chi/chi/v5"
@@ -62,11 +63,6 @@ const (
 	browserContextDone
 )
 
-type browserError struct {
-	kind errorKind
-	err  error
-}
-
 func NewService(client browserclient.Client, config ServiceConfig) *Service {
 	return &Service{
 		client: client,
@@ -109,47 +105,9 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	template := &browserv1.Browser{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
-		},
-		Spec: browserv1.BrowserSpec{
-			BrowserName:    processed.GetBrowserName(),
-			BrowserVersion: processed.GetBrowserVersion(),
-		},
-	}
-
 	opts := processed.GetSelenosisOptions()
-	if opts != nil {
-		template.ObjectMeta.Annotations, err = setSelenosisOptions(template.ObjectMeta.Annotations, opts)
-		if err != nil {
-			log.Err(err).Msg("failed to set selenosis options annotation")
-			writeErrorResponse(rw, http.StatusInternalServerError, selenium.Error("failed to set selenosis options annotation", err))
-			return
-		}
-	}
-
-	setOwnerReference(req.Context(), template)
-
-	log = log.With().
-		Str("browserName", template.Spec.BrowserName).
-		Str("browserVersion", template.Spec.BrowserVersion).
-		Str("namespace", s.config.Namespace).
-		Logger()
-
-	ctx, cancel := context.WithTimeout(req.Context(), s.config.BrowserStartTimeout)
-	defer cancel()
-
-	_, podIP, waitErr := s.createBrowserAndWait(ctx, log, template)
-	if waitErr != nil {
-		writeCreateSessionWaitError(rw, waitErr)
-		return
-	}
-
-	ip := net.ParseIP(podIP)
-	if ip == nil {
-		log.Err(fmt.Errorf("invalid pod IP: %s", podIP)).Msg("failed to parse pod IP")
-		writeErrorResponse(rw, http.StatusInternalServerError, selenium.Error("failed to parse browser ip", ErrInternal))
+	podIP, _, ok := s.createBrowser(rw, req, processed.GetBrowserName(), processed.GetBrowserVersion(), opts, writeCreateSessionWaitError)
+	if !ok {
 		return
 	}
 
@@ -172,7 +130,10 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 			Msg("session create request modified")
 	}
 
-	rp := proxy.NewHTTPReverseProxy(proxy.WithRequestModifier(reqModifier))
+	rp := proxy.NewHTTPReverseProxy(
+		proxy.WithRequestModifier(reqModifier),
+		proxy.WithErrorHandler(createSessionProxyErrorHandler(log, podIP)),
+	)
 	rp.ServeHTTP(rw, req)
 }
 
@@ -229,7 +190,10 @@ func (s *Service) ProxySession(rw http.ResponseWriter, req *http.Request) {
 		log.Info().Str("sessionId", sessionId).Str("ip", ip.String()).Msg("session proxy request modified")
 	}
 
-	rp := proxy.NewHTTPReverseProxy(proxy.WithRequestModifier(reqModifier))
+	rp := proxy.NewHTTPReverseProxy(
+		proxy.WithRequestModifier(reqModifier),
+		proxy.WithErrorHandler(sessionProxyErrorHandler(log, sessionId)),
+	)
 	rp.ServeHTTP(rw, req)
 }
 
@@ -257,60 +221,21 @@ func (s *Service) Playwright(rw http.ResponseWriter, req *http.Request) {
 
 	name := chi.URLParam(req, "name")
 	version := chi.URLParam(req, "version")
-	if version == "" || name == "" {
+	if name == "" || version == "" {
 		log.Error().Str("name", name).Str("version", version).Msg("missing required url params: name or version")
 		http.Error(rw, fmt.Sprintf("missing required url param: name=%s version=%s", name, version), http.StatusNotFound)
 		return
 	}
 
-	selenosisOpts, err := parseSelenosisOptions(req.URL.Query(), defaultParseLimits())
+	opts, err := parseSelenosisOptions(req.URL.Query(), defaultParseLimits())
 	if err != nil {
 		log.Err(err).Msg("failed to parse selenosis options from query parameters")
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	template := &browserv1.Browser{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
-		},
-		Spec: browserv1.BrowserSpec{
-			BrowserName:    name,
-			BrowserVersion: version,
-		},
-	}
-
-	if len(selenosisOpts) > 0 {
-		template.ObjectMeta.Annotations, err = setSelenosisOptions(template.ObjectMeta.Annotations, selenosisOpts)
-		if err != nil {
-			log.Err(err).Msg("failed to set selenosis options annotation")
-			http.Error(rw, err.Error(), http.StatusBadRequest)
-			return
-		}
-	}
-
-	setOwnerReference(req.Context(), template)
-
-	log = log.With().
-		Str("browserName", template.Spec.BrowserName).
-		Str("browserVersion", template.Spec.BrowserVersion).
-		Str("namespace", s.config.Namespace).
-		Logger()
-
-	ctx, cancel := context.WithTimeout(req.Context(), s.config.BrowserStartTimeout)
-	defer cancel()
-
-	_, podIP, waitErr := s.createBrowserAndWait(ctx, log, template)
-	if waitErr != nil {
-		writePlaywrightWaitError(rw, waitErr)
-		return
-	}
-
-	ip := net.ParseIP(podIP)
-	uuid, err := ipuuid.IPToUUID(ip)
-	if err != nil {
-		log.Err(err).Str("podIP", podIP).Msg("failed to convert IP to UUID")
-		http.Error(rw, "failed to convert IP to UUID", http.StatusInternalServerError)
+	podIP, sessionUUID, ok := s.createBrowser(rw, req, name, version, opts, writePlaywrightWaitError)
+	if !ok {
 		return
 	}
 
@@ -322,13 +247,13 @@ func (s *Service) Playwright(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		query := url.Query()
-		query.Add("ipuuid", uuid.String())
+		query.Add("ipuuid", sessionUUID.String())
 
 		url.RawQuery = query.Encode()
 		return url, nil
 	}
 
-	log.Info().Str("ip", ip.String()).Msg("proxying playwright request")
+	log.Info().Str("ip", podIP).Msg("proxying playwright request")
 
 	rp := proxy.NewWebSocketReverseProxy(resolver)
 	rp.ServeHTTP(rw, req)
@@ -368,8 +293,150 @@ func (s *Service) RouteHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	log.Info().Msg("proxying http proxy request")
 
-	rp := proxy.NewHTTPReverseProxy(proxy.WithRequestModifier(reqModifier))
+	rp := proxy.NewHTTPReverseProxy(
+		proxy.WithRequestModifier(reqModifier),
+		proxy.WithErrorHandler(routeHTTPProxyErrorHandler(log, sessionId)),
+	)
 	rp.ServeHTTP(rw, req)
+}
+
+func (s *Service) McpHandler(rw http.ResponseWriter, req *http.Request) {
+	log := logctx.FromContext(req.Context())
+
+	sessionId := req.Header.Get("Mcp-Session-Id")
+	if sessionId == "" && req.Method == http.MethodPost {
+
+		name := req.URL.Query().Get("browser")
+		version := req.URL.Query().Get("version")
+		if name == "" || version == "" {
+			log.Error().Str("browser", name).Str("version", version).Msg("missing required query params: browser or version")
+			jsonrpc.WriteError(rw, http.StatusBadRequest, jsonrpc.InvalidParams, "Bad Request: browser and version query params are required")
+			return
+		}
+
+		selenosisOpts, err := parseSelenosisOptions(req.URL.Query(), defaultParseLimits())
+		if err != nil {
+			log.Err(err).Msg("failed to parse selenosis options from query parameters")
+			jsonrpc.WriteError(rw, http.StatusBadRequest, jsonrpc.InvalidParams, "Bad Request: "+err.Error())
+			return
+		}
+
+		podIP, _, ok := s.createBrowser(rw, req, name, version, selenosisOpts, writeMcpWaitError)
+		if !ok {
+			return
+		}
+
+		host := s.sidecarHost(podIP)
+
+		log.Info().Str("ip", podIP).Msg("proxying mcp initialize request")
+
+		reqModifier := func(r *http.Request) {
+			r.URL = &url.URL{
+				Scheme:   "http",
+				Host:     host,
+				Path:     "/mcp",
+				RawQuery: req.URL.RawQuery,
+			}
+			r.Host = host
+		}
+
+		rp := proxy.NewHTTPReverseProxy(
+			proxy.WithRequestModifier(reqModifier),
+			proxy.WithErrorHandler(mcpInitProxyErrorHandler(log, podIP)),
+		)
+		rp.ServeHTTP(rw, req)
+		return
+	}
+
+	if sessionId == "" {
+		log.Error().Msg("missing Mcp-Session-Id header")
+		jsonrpc.WriteError(rw, http.StatusBadRequest, jsonrpc.InvalidParams, "Bad Request: Mcp-Session-Id header is required")
+		return
+	}
+
+	ip, err := parseSessionID(sessionId)
+	if err != nil {
+		log.Error().Str("mcpSessionId", sessionId).Msg("invalid Mcp-Session-Id")
+		jsonrpc.WriteError(rw, http.StatusBadRequest, jsonrpc.InvalidParams, "Bad Request: invalid Mcp-Session-Id")
+		return
+	}
+
+	host := s.sidecarHost(ip.String())
+
+	log.Info().Str("ip", ip.String()).Msg("proxying mcp request")
+
+	reqModifier := func(r *http.Request) {
+		r.URL = &url.URL{
+			Scheme:   "http",
+			Host:     host,
+			Path:     "/mcp",
+			RawQuery: req.URL.RawQuery,
+		}
+		r.Host = host
+	}
+
+	rp := proxy.NewHTTPReverseProxy(
+		proxy.WithRequestModifier(reqModifier),
+		proxy.WithErrorHandler(mcpProxyErrorHandler(log, ip.String())),
+	)
+	rp.ServeHTTP(rw, req)
+}
+
+func (s *Service) createBrowser(rw http.ResponseWriter, req *http.Request, name, version string, opts map[string]any, writeWaitError func(http.ResponseWriter, *browserError)) (string, uuid.UUID, bool) {
+	log := logctx.FromContext(req.Context())
+
+	template := &browserv1.Browser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+		},
+		Spec: browserv1.BrowserSpec{
+			BrowserName:    name,
+			BrowserVersion: version,
+		},
+	}
+
+	var err error
+	if len(opts) > 0 {
+		template.ObjectMeta.Annotations, err = setSelenosisOptions(template.ObjectMeta.Annotations, opts)
+		if err != nil {
+			log.Err(err).Msg("failed to set selenosis options annotation")
+			http.Error(rw, err.Error(), http.StatusBadRequest)
+			return "", uuid.UUID{}, false
+		}
+	}
+
+	setOwnerReference(req.Context(), template)
+
+	log = log.With().
+		Str("browserName", template.Spec.BrowserName).
+		Str("browserVersion", template.Spec.BrowserVersion).
+		Str("namespace", s.config.Namespace).
+		Logger()
+
+	ctx, cancel := context.WithTimeout(req.Context(), s.config.BrowserStartTimeout)
+	defer cancel()
+
+	_, podIP, waitErr := s.createBrowserAndWait(ctx, log, template)
+	if waitErr != nil {
+		writeWaitError(rw, waitErr)
+		return "", uuid.UUID{}, false
+	}
+
+	ip := net.ParseIP(podIP)
+	if ip == nil {
+		log.Err(fmt.Errorf("invalid pod IP: %s", podIP)).Msg("failed to parse pod IP")
+		http.Error(rw, "failed to get browser IP", http.StatusInternalServerError)
+		return "", uuid.UUID{}, false
+	}
+
+	sessionUUID, err := ipuuid.IPToUUID(ip)
+	if err != nil {
+		log.Err(err).Str("podIP", podIP).Msg("failed to convert IP to UUID")
+		http.Error(rw, "failed to convert IP to UUID", http.StatusInternalServerError)
+		return "", uuid.UUID{}, false
+	}
+
+	return podIP, sessionUUID, true
 }
 
 func (s *Service) createBrowserAndWait(ctx context.Context, logger zerolog.Logger, template *browserv1.Browser) (string, string, *browserError) {
@@ -441,44 +508,6 @@ func parseSessionID(sessionId string) (net.IP, error) {
 	return ipuuid.UUIDToIP(uid), nil
 }
 
-func writeCreateSessionWaitError(rw http.ResponseWriter, waitErr *browserError) {
-	switch waitErr.kind {
-	case browserCreate:
-		writeErrorResponse(rw, http.StatusInternalServerError, selenium.Error("failed to create browser", waitErr.err))
-	case browserEventsStart:
-		writeErrorResponse(rw, http.StatusInternalServerError, selenium.Error("failed to start browser event stream", waitErr.err))
-	case browserStreamClosed:
-		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(ErrInternal))
-	case browserFailed:
-		writeErrorResponse(rw, http.StatusInternalServerError, selenium.Error("browser failed to start", ErrInternal))
-	case browserStreamError:
-		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(waitErr.err))
-	case browserContextDone:
-		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(ErrInternal))
-	default:
-		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(ErrInternal))
-	}
-}
-
-func writePlaywrightWaitError(rw http.ResponseWriter, waitErr *browserError) {
-	switch waitErr.kind {
-	case browserCreate:
-		http.Error(rw, "failed to create browser resource", http.StatusInternalServerError)
-	case browserEventsStart:
-		http.Error(rw, "failed to start browser event stream", http.StatusInternalServerError)
-	case browserStreamClosed:
-		http.Error(rw, "browser event stream closed unexpectedly", http.StatusInternalServerError)
-	case browserFailed:
-		http.Error(rw, "browser failed to start", http.StatusInternalServerError)
-	case browserStreamError:
-		http.Error(rw, "browser event stream error", http.StatusInternalServerError)
-	case browserContextDone:
-		http.Error(rw, "context cancelled, stopping browser event stream", http.StatusInternalServerError)
-	default:
-		http.Error(rw, "internal server error", http.StatusInternalServerError)
-	}
-}
-
 func setOwnerReference(ctx context.Context, template *browserv1.Browser) {
 	owner, ok := auth.OwnerFrom(ctx)
 	if ok {
@@ -490,9 +519,7 @@ func setOwnerReference(ctx context.Context, template *browserv1.Browser) {
 }
 
 func writeErrorResponse(rw http.ResponseWriter, status int, err *selenium.SeleniumError) {
-	rw.Header().Set("Content-Type", "application/json")
-	rw.WriteHeader(status)
-	json.NewEncoder(rw).Encode(err)
+	selenium.WriteError(rw, status, err)
 }
 
 func externalBaseURL(r *http.Request) *url.URL {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/alcounit/browser-service/pkg/event"
 	"github.com/alcounit/selenosis/v2/pkg/auth"
 	"github.com/alcounit/selenosis/v2/pkg/ipuuid"
+	"github.com/alcounit/selenosis/v2/pkg/jsonrpc"
 	"github.com/alcounit/selenosis/v2/pkg/proxy"
 	"github.com/alcounit/selenosis/v2/pkg/selenium"
 	"github.com/go-chi/chi/v5"
@@ -199,7 +200,12 @@ func TestCreateSessionInvalidPodIP(t *testing.T) {
 
 	svc.CreateSession(rw, req)
 
-	verifyResponseError(t, rw, http.StatusInternalServerError, selenium.Error("failed to parse browser ip", ErrInternal))
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "failed to get browser IP") {
+		t.Fatalf("unexpected body: %q", rw.Body.String())
+	}
 }
 
 func TestCreateSessionSuccess(t *testing.T) {
@@ -413,6 +419,48 @@ func TestProxySessionHTTP(t *testing.T) {
 	if gotReq.Header.Get("X-Selenosis-External-URL") == "" {
 		t.Fatal("expected external url header")
 	}
+}
+
+func TestProxySessionUpstreamUnreachable(t *testing.T) {
+	ip := net.ParseIP("127.0.0.1")
+	uid, _ := ipuuid.IPToUUID(ip)
+	sessionId := uid.String()
+
+	setTestTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, dialErr()
+	}))
+
+	svc := NewService(&fakeClient{}, ServiceConfig{SidecarPort: "4444"})
+	req := newRequestWithParams(http.MethodGet, "/wd/hub/session/"+sessionId+"/url", nil, map[string]string{"sessionId": sessionId})
+	rw := httptest.NewRecorder()
+
+	svc.ProxySession(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "invalid session id") {
+		t.Fatalf("expected invalid session id error, got %s", rw.Body.String())
+	}
+}
+
+func TestMcpHandlerUpstreamUnreachable(t *testing.T) {
+	ip := net.ParseIP("127.0.0.1")
+	uid, _ := ipuuid.IPToUUID(ip)
+	sessionId := uid.String()
+
+	setTestTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, dialErr()
+	}))
+
+	svc := NewService(&fakeClient{}, ServiceConfig{SidecarPort: "4444"})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Mcp-Session-Id", sessionId)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	assertMcpError(t, rw, http.StatusNotFound, -32001)
 }
 
 func TestSessionStatus(t *testing.T) {
@@ -660,7 +708,7 @@ func TestPlaywrightInvalidPodIP(t *testing.T) {
 	if rw.Code != http.StatusInternalServerError {
 		t.Fatalf("expected status 500, got %d", rw.Code)
 	}
-	if !strings.Contains(rw.Body.String(), "failed to convert IP to UUID") {
+	if !strings.Contains(rw.Body.String(), "failed to get browser IP") {
 		t.Fatalf("unexpected body: %q", rw.Body.String())
 	}
 }
@@ -694,7 +742,7 @@ func TestPlaywrightNilBrowserEventIsIgnored(t *testing.T) {
 	if rw.Code != http.StatusInternalServerError {
 		t.Fatalf("expected status 500, got %d", rw.Code)
 	}
-	if !strings.Contains(rw.Body.String(), "failed to convert IP to UUID") {
+	if !strings.Contains(rw.Body.String(), "failed to get browser IP") {
 		t.Fatalf("unexpected body: %q", rw.Body.String())
 	}
 }
@@ -743,6 +791,423 @@ func TestPlaywrightProxyAttemptAndOwnerLabel(t *testing.T) {
 	}
 	if fc.created.ObjectMeta.Labels[browserv1.SelenosisOwnerLabelKey] != "qa-owner" {
 		t.Fatalf("unexpected owner label: %q", fc.created.ObjectMeta.Labels[browserv1.SelenosisOwnerLabelKey])
+	}
+}
+
+func mcpSessionID(t *testing.T, ip string) string {
+	t.Helper()
+	uid, err := ipuuid.IPToUUID(net.ParseIP(ip))
+	if err != nil {
+		t.Fatalf("failed to build session id: %v", err)
+	}
+	return uid.String()
+}
+
+func runningStream(podIP string) *fakeStream {
+	stream := newFakeStream()
+	stream.events <- &event.BrowserEvent{
+		Browser: &browserv1.Browser{
+			Status: browserv1.BrowserStatus{Phase: "Running", PodIP: podIP},
+		},
+	}
+	return stream
+}
+
+func mcpProxyRequest(t *testing.T, method, path string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	req.Header.Set("Mcp-Session-Id", mcpSessionID(t, "127.0.0.1"))
+	return req
+}
+
+func TestMcpHandlerInitMissingParams(t *testing.T) {
+	svc := NewService(&fakeClient{}, ServiceConfig{})
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"no params", "/mcp"},
+		{"missing version", "/mcp?browser=chromium"},
+		{"missing browser", "/mcp?version=123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, nil)
+			rw := httptest.NewRecorder()
+
+			svc.McpHandler(rw, req)
+
+			assertMcpError(t, rw, http.StatusBadRequest, jsonrpc.InvalidParams)
+		})
+	}
+}
+
+func TestMcpHandlerInitParseOptionsError(t *testing.T) {
+	svc := NewService(&fakeClient{}, ServiceConfig{})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123&labels.bad!=x", nil)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "invalid label key") {
+		t.Fatalf("expected parse error, got %q", rw.Body.String())
+	}
+}
+
+func TestMcpHandlerInitCreateBrowserError(t *testing.T) {
+	fc := &fakeClient{createErr: errors.New("boom")}
+	svc := NewService(fc, ServiceConfig{Namespace: "ns", BrowserStartTimeout: time.Second})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123", nil)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "failed to create browser resource") {
+		t.Fatalf("unexpected body: %q", rw.Body.String())
+	}
+}
+
+func TestMcpHandlerInitEventsError(t *testing.T) {
+	fc := &fakeClient{streamErr: errors.New("stream failed")}
+	svc := NewService(fc, ServiceConfig{Namespace: "ns", BrowserStartTimeout: time.Second})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123", nil)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "failed to start browser event stream") {
+		t.Fatalf("unexpected body: %q", rw.Body.String())
+	}
+}
+
+func TestMcpHandlerInitStreamClosed(t *testing.T) {
+	stream := newFakeStream()
+	stream.Close()
+
+	fc := &fakeClient{
+		stream:       stream,
+		createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+	}
+	svc := NewService(fc, ServiceConfig{Namespace: "ns", BrowserStartTimeout: time.Second})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123", nil)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rw.Code)
+	}
+}
+
+func TestMcpHandlerInitFailedEvent(t *testing.T) {
+	stream := newFakeStream()
+	stream.events <- &event.BrowserEvent{
+		Browser: &browserv1.Browser{
+			Status: browserv1.BrowserStatus{Phase: "Failed", Reason: "oops"},
+		},
+	}
+
+	fc := &fakeClient{
+		stream:       stream,
+		createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+	}
+	svc := NewService(fc, ServiceConfig{Namespace: "ns", BrowserStartTimeout: time.Second})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123", nil)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "browser failed to start") {
+		t.Fatalf("unexpected body: %q", rw.Body.String())
+	}
+}
+
+func TestMcpHandlerInitContextDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fc := &fakeClient{
+		stream:       newFakeStream(),
+		createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+	}
+	svc := NewService(fc, ServiceConfig{Namespace: "ns", BrowserStartTimeout: time.Second})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123", nil).WithContext(ctx)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "context cancelled") {
+		t.Fatalf("unexpected body: %q", rw.Body.String())
+	}
+}
+
+func TestMcpHandlerInitInvalidPodIP(t *testing.T) {
+	fc := &fakeClient{
+		stream:       runningStream(""),
+		createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+	}
+	svc := NewService(fc, ServiceConfig{Namespace: "ns", BrowserStartTimeout: time.Second})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123", nil)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "failed to get browser IP") {
+		t.Fatalf("unexpected body: %q", rw.Body.String())
+	}
+}
+
+func TestMcpHandlerInitSuccess(t *testing.T) {
+	var gotReq *http.Request
+	setTestTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return response(http.StatusOK, "{}"), nil
+	}))
+
+	fc := &captureClient{
+		fakeClient: fakeClient{
+			stream:       runningStream("127.0.0.1"),
+			createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+		},
+	}
+	svc := NewService(fc, ServiceConfig{
+		Namespace:           "ns",
+		SidecarPort:         "4444",
+		BrowserStartTimeout: time.Second,
+	})
+
+	ctx := auth.WithOwner(context.Background(), auth.Owner{Name: "mcp-user"})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123", nil).WithContext(ctx)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+	if gotReq == nil {
+		t.Fatal("expected transport to be called")
+	}
+	if gotReq.URL.Host != "127.0.0.1:4444" {
+		t.Fatalf("unexpected target host: %s", gotReq.URL.Host)
+	}
+	if gotReq.URL.Path != "/mcp" {
+		t.Fatalf("expected path /mcp, got %s", gotReq.URL.Path)
+	}
+	if fc.created == nil {
+		t.Fatal("expected browser to be created")
+	}
+	if fc.created.ObjectMeta.Labels[browserv1.SelenosisOwnerLabelKey] != "mcp-user" {
+		t.Fatalf("unexpected owner label: %q", fc.created.ObjectMeta.Labels[browserv1.SelenosisOwnerLabelKey])
+	}
+}
+
+func TestMcpHandlerInitSelenosisOptions(t *testing.T) {
+	setTestTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return response(http.StatusOK, "{}"), nil
+	}))
+
+	fc := &captureClient{
+		fakeClient: fakeClient{
+			stream:       runningStream("127.0.0.1"),
+			createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+		},
+	}
+	svc := NewService(fc, ServiceConfig{
+		Namespace:           "ns",
+		SidecarPort:         "4444",
+		BrowserStartTimeout: time.Second,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123&labels.env=test", nil)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+	if fc.created == nil {
+		t.Fatal("expected browser to be created")
+	}
+	if fc.created.ObjectMeta.Annotations[browserv1.SelenosisOptionsAnnotationKey] == "" {
+		t.Fatalf("expected %s annotation", browserv1.SelenosisOptionsAnnotationKey)
+	}
+}
+
+func TestCreateBrowserSetOptionsError(t *testing.T) {
+	svc := NewService(&fakeClient{}, ServiceConfig{Namespace: "ns"})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	rw := httptest.NewRecorder()
+
+	opts := map[string]any{"bad": make(chan int)}
+	if _, _, ok := svc.createBrowser(rw, req, "chromium", "123", opts, writeMcpWaitError); ok {
+		t.Fatal("expected createBrowser to fail on unmarshalable options")
+	}
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rw.Code)
+	}
+}
+
+func TestMcpHandlerMissingHeaderGet(t *testing.T) {
+	svc := NewService(&fakeClient{}, ServiceConfig{})
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	assertMcpError(t, rw, http.StatusBadRequest, jsonrpc.InvalidParams)
+}
+
+func TestMcpHandlerMissingHeaderDelete(t *testing.T) {
+	svc := NewService(&fakeClient{}, ServiceConfig{})
+	req := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	assertMcpError(t, rw, http.StatusBadRequest, jsonrpc.InvalidParams)
+}
+
+func TestMcpHandlerInvalidHeader(t *testing.T) {
+	svc := NewService(&fakeClient{}, ServiceConfig{})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Mcp-Session-Id", "not-a-uuid")
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	assertMcpError(t, rw, http.StatusBadRequest, jsonrpc.InvalidParams)
+}
+
+func TestMcpHandlerRoutesToMcp(t *testing.T) {
+	var gotReq *http.Request
+	setTestTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return response(http.StatusOK, "{}"), nil
+	}))
+
+	svc := NewService(&fakeClient{}, ServiceConfig{SidecarPort: "4444"})
+	req := mcpProxyRequest(t, http.MethodPost, "/mcp")
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if gotReq == nil {
+		t.Fatal("expected transport to be called")
+	}
+	if gotReq.URL.Host != "127.0.0.1:4444" {
+		t.Fatalf("unexpected target host: %s", gotReq.URL.Host)
+	}
+	if gotReq.URL.Path != "/mcp" {
+		t.Fatalf("expected path /mcp, got %s", gotReq.URL.Path)
+	}
+}
+
+func TestMcpHandlerGetRoutesToMcp(t *testing.T) {
+	var gotReq *http.Request
+	setTestTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return response(http.StatusOK, "{}"), nil
+	}))
+
+	svc := NewService(&fakeClient{}, ServiceConfig{SidecarPort: "4444"})
+	req := mcpProxyRequest(t, http.MethodGet, "/mcp")
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if gotReq == nil {
+		t.Fatal("expected transport to be called")
+	}
+	if gotReq.URL.Path != "/mcp" {
+		t.Fatalf("expected path /mcp, got %s", gotReq.URL.Path)
+	}
+}
+
+func TestMcpHandlerDeleteRoutesToMcp(t *testing.T) {
+	var gotReq *http.Request
+	setTestTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return response(http.StatusOK, "{}"), nil
+	}))
+
+	svc := NewService(&fakeClient{}, ServiceConfig{SidecarPort: "4444"})
+	req := mcpProxyRequest(t, http.MethodDelete, "/mcp")
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if gotReq == nil {
+		t.Fatal("expected transport to be called")
+	}
+	if gotReq.Method != http.MethodDelete {
+		t.Fatalf("expected DELETE method, got %s", gotReq.Method)
+	}
+	if gotReq.URL.Path != "/mcp" {
+		t.Fatalf("expected path /mcp, got %s", gotReq.URL.Path)
+	}
+}
+
+func TestMcpHandlerPreservesQueryParams(t *testing.T) {
+	var gotReq *http.Request
+	setTestTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return response(http.StatusOK, "{}"), nil
+	}))
+
+	svc := NewService(&fakeClient{}, ServiceConfig{SidecarPort: "4444"})
+	req := mcpProxyRequest(t, http.MethodPost, "/mcp?foo=bar&baz=qux")
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if gotReq == nil {
+		t.Fatal("expected transport to be called")
+	}
+	if gotReq.URL.RawQuery != "foo=bar&baz=qux" {
+		t.Fatalf("expected query params to be preserved, got %q", gotReq.URL.RawQuery)
+	}
+}
+
+func TestMcpHandlerPreservesHeaders(t *testing.T) {
+	var gotReq *http.Request
+	setTestTransport(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return response(http.StatusOK, "{}"), nil
+	}))
+
+	svc := NewService(&fakeClient{}, ServiceConfig{SidecarPort: "4444"})
+	req := mcpProxyRequest(t, http.MethodPost, "/mcp")
+	req.Header.Set("X-Custom-Header", "custom-value")
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if gotReq == nil {
+		t.Fatal("expected transport to be called")
+	}
+	if got := gotReq.Header.Get("X-Custom-Header"); got != "custom-value" {
+		t.Fatalf("expected header to be preserved, got %q", got)
 	}
 }
 
@@ -966,6 +1431,61 @@ func TestWritePlaywrightWaitError(t *testing.T) {
 			}
 			if got := strings.TrimSpace(rw.Body.String()); got != tt.expected {
 				t.Fatalf("expected body %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestWriteMcpWaitError(t *testing.T) {
+	tests := []struct {
+		name     string
+		waitErr  *browserError
+		expected string
+	}{
+		{
+			name:     "create error",
+			waitErr:  &browserError{kind: browserCreate, err: errors.New("create failed")},
+			expected: "failed to create browser resource",
+		},
+		{
+			name:     "events start error",
+			waitErr:  &browserError{kind: browserEventsStart, err: errors.New("stream start failed")},
+			expected: "failed to start browser event stream",
+		},
+		{
+			name:     "stream closed",
+			waitErr:  &browserError{kind: browserStreamClosed},
+			expected: "browser event stream closed unexpectedly",
+		},
+		{
+			name:     "browser failed",
+			waitErr:  &browserError{kind: browserFailed},
+			expected: "browser failed to start",
+		},
+		{
+			name:     "stream error",
+			waitErr:  &browserError{kind: browserStreamError, err: errors.New("stream failed")},
+			expected: "browser event stream error",
+		},
+		{
+			name:     "context done",
+			waitErr:  &browserError{kind: browserContextDone},
+			expected: "context cancelled, stopping browser event stream",
+		},
+		{
+			name:     "unknown kind",
+			waitErr:  &browserError{kind: errorKind(999)},
+			expected: "Internal error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := httptest.NewRecorder()
+			writeMcpWaitError(rw, tt.waitErr)
+			assertMcpError(t, rw, http.StatusInternalServerError, -32603)
+			if !strings.Contains(rw.Body.String(), tt.expected) {
+				t.Fatalf("expected body to contain %q, got %q", tt.expected, rw.Body.String())
 			}
 		})
 	}


### PR DESCRIPTION
  ## Summary

  Adds **MCP (Model Context Protocol)** support to selenosis: a stateless
  Streamable HTTP endpoint that provisions a browser pod on initialize and
  proxies subsequent MCP/CDP traffic to the per-pod sidecar, reusing the same
  pod-routing model as the existing WebDriver/Playwright flows. Also introduces
  a shared, structured error layer and modernizes the reverse proxy.

  ## Changes

  **MCP endpoint**
  - Mount `/mcp` (`POST`/`GET`/`DELETE`) → `McpHandler` (`cmd/selenosis/main.go`).
  - `initialize` (header-less `POST`) creates a `Browser` CR and proxies to the
    sidecar; later requests resolve the target pod from the `Mcp-Session-Id`
    header. Unknown/expired sessions return **404** so clients re-initialize.

  **Error handling (`service/errors.go`, `pkg/jsonrpc`)**
  - New error-classification layer: upstream **dial** failures → `404`
    (pod unreachable / session expired); all other failures → `500`.
  - MCP errors emitted as **JSON-RPC 2.0** objects via the new `pkg/jsonrpc`
    package (`WriteError` + centralized codes: `InvalidParams`, `InvalidRequest`,
    `InternalError`, `SessionNotFound`).
  - Selenium errors emitted in the **W3C** shape via new `selenium.WriteError`.
  
  **Proxy (`pkg/proxy`)**
  - `HTTPReverseProxy`: migrate from the deprecated `Director` to `Rewrite`
    (`SetXForwarded`, `ProxyRequest` In/Out), with a stored request modifier and
    typed `ResponseModifier`.
  - `WSProxy`: close the upstream connection when the client upgrade fails
    (fixes a connection leak).

  **Misc**
  - Guard `auth.Watch` behind a non-nil auth store (`main.go`).
  - README: MCP usage, error-response reference, and synced build variables.