### PR TITLE
Hub hostname provenance + structured request-scoped logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ holds nothing — Kubernetes is the source of truth.
 [![Docker Pulls](https://img.shields.io/docker/pulls/alcounit/selenosis.svg)](https://hub.docker.com/r/alcounit/selenosis)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/selenosis)](https://artifacthub.io/packages/search?repo=selenosis)
 [![codecov](https://codecov.io/gh/alcounit/selenosis/branch/main/graph/badge.svg)](https://codecov.io/gh/alcounit/selenosis)
-[![Go Report Card](https://goreportcard.com/badge/github.com/alcounit/selenosis/v2)](https://goreportcard.com/report/github.com/alcounit/selenosis/v2)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 
 <p align="center">

--- a/cmd/selenosis/main.go
+++ b/cmd/selenosis/main.go
@@ -20,6 +20,30 @@ import (
 	"github.com/rs/zerolog"
 )
 
+func requestContextMiddleware(logger zerolog.Logger, hostname string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(rw http.ResponseWriter, req *http.Request) {
+
+			reqId := uuid.NewString()
+
+			l := logger.With().
+				Str("method", req.Method).
+				Str("path", req.URL.Path).
+				Str("reqId", reqId).
+				Str("hostname", hostname).
+				Logger()
+
+			req.Header.Add("X-Selenosis-Request-ID", reqId)
+			req.Header.Set("X-Selenosis-Hostname", hostname)
+			ctx := req.Context()
+			ctx = logctx.IntoContext(ctx, l)
+
+			next.ServeHTTP(rw, req.WithContext(ctx))
+		}
+		return http.HandlerFunc(fn)
+	}
+}
+
 func main() {
 
 	zerolog.TimeFieldFormat = time.RFC3339
@@ -51,26 +75,14 @@ func main() {
 
 	svc := service.NewService(client, cfg)
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to resolve hostname, using fallback")
+		hostname = "unknown"
+	}
+
 	router := chi.NewRouter()
-	router.Use(func(next http.Handler) http.Handler {
-		fn := func(rw http.ResponseWriter, req *http.Request) {
-
-			reqId := uuid.NewString()
-
-			logger := log.With().
-				Str("method", req.Method).
-				Str("path", req.URL.Path).
-				Str("reqId", reqId).
-				Logger()
-
-			req.Header.Add("Selenosis-Request-ID", reqId)
-			ctx := req.Context()
-			ctx = logctx.IntoContext(ctx, logger)
-
-			next.ServeHTTP(rw, req.WithContext(ctx))
-		}
-		return http.HandlerFunc(fn)
-	})
+	router.Use(requestContextMiddleware(log, hostname))
 
 	router.Use(basicAuthMiddleware(authStore, log))
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	dario.cat/mergo v1.0.2
-	github.com/alcounit/browser-controller v0.0.8
-	github.com/alcounit/browser-service v0.0.7
+	github.com/alcounit/browser-controller v0.0.9
+	github.com/alcounit/browser-service v0.0.8
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
-github.com/alcounit/browser-controller v0.0.8 h1:hauzkisDiUsGoIKUoQqvBmi4/MrixzGp55PnZIUA6rY=
-github.com/alcounit/browser-controller v0.0.8/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
-github.com/alcounit/browser-service v0.0.7 h1:Pv33j3QrtjZaa4QxoohzCGn1urJ20kiMLgDwKeg1y1Q=
-github.com/alcounit/browser-service v0.0.7/go.mod h1:Oozpap9DWLAu2ViuJua5Q9KHXziVZUUFhacC//SVlXw=
+github.com/alcounit/browser-controller v0.0.9 h1:Z10ryX+/QrgV+kB/Y+WT0WIsigcB2cPS9RVv7V/auSg=
+github.com/alcounit/browser-controller v0.0.9/go.mod h1:tpj7lwi2UJ49xt/vnEsZKAu5HAvtQJ7xbbcJO3wn+dc=
+github.com/alcounit/browser-service v0.0.8 h1:9qn7oRrsmz1/E31gnPKXwSDArbZf3k4ts8fWTBoz0Jg=
+github.com/alcounit/browser-service v0.0.8/go.mod h1:SzJ5hMhNJh6McA3cl3oceJjNqLCjNcqBT8tEnPuxniI=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/service/service.go
+++ b/service/service.go
@@ -106,12 +106,18 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	opts := processed.GetSelenosisOptions()
-	podIP, _, ok := s.createBrowser(rw, req, processed.GetBrowserName(), processed.GetBrowserVersion(), opts, writeCreateSessionWaitError)
+	podIP, browserHostname, _, ok := s.createBrowser(rw, req, processed.GetBrowserName(), processed.GetBrowserVersion(), opts, writeCreateSessionWaitError)
 	if !ok {
 		return
 	}
 
-	log.Info().Str("ip", podIP).Msg("proxying session create request")
+	log = log.With().
+		Dict("Browser", zerolog.Dict().
+			Str("ip", podIP).
+			Str("hostname", browserHostname)).
+		Logger()
+
+	log.Info().Msg("proxying session create request")
 
 	reqModifier := func(r *http.Request) {
 		r.Header.Set("X-Selenosis-External-URL", externalBaseURL(req).String())
@@ -126,7 +132,6 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 		r.ContentLength = int64(len(body))
 
 		log.Info().
-			Str("ip", podIP).
 			Msg("session create request modified")
 	}
 
@@ -146,16 +151,23 @@ func (s *Service) ProxySession(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	ip, err := parseSessionID(sessionId)
+	podIp, err := parseSessionID(sessionId)
 	if err != nil {
 		log.Error().Msg("invalid url param: sessionId")
 		writeErrorResponse(rw, http.StatusBadRequest, selenium.ErrInvalidArgument(errors.ErrUnsupported))
 		return
 	}
 
-	log.Info().Str("sessionId", sessionId).Str("ip", ip.String()).Msg("proxying session request")
+	log = log.With().
+		Dict("Browser", zerolog.Dict().
+			Str("ip", podIp.String())).
+		Str("sessionId", sessionId).
+		Logger()
 
-	host := s.sidecarHost(ip.String())
+	log.Info().
+		Msg("proxying session request")
+
+	host := s.sidecarHost(podIp.String())
 	if proxy.IsWebSocketRequest(req) {
 		resolver := func(r *http.Request) (*url.URL, error) {
 			url := &url.URL{
@@ -168,10 +180,7 @@ func (s *Service) ProxySession(rw http.ResponseWriter, req *http.Request) {
 			return url, nil
 		}
 
-		log.Info().
-			Str("sessionId", sessionId).
-			Str("ip", ip.String()).
-			Msg("proxying websocket request")
+		log.Info().Msg("proxying websocket request")
 
 		rp := proxy.NewWebSocketReverseProxy(resolver)
 		rp.ServeHTTP(rw, req)
@@ -187,7 +196,7 @@ func (s *Service) ProxySession(rw http.ResponseWriter, req *http.Request) {
 		}
 		r.Host = req.Host
 
-		log.Info().Str("sessionId", sessionId).Str("ip", ip.String()).Msg("session proxy request modified")
+		log.Info().Msg("session proxy request modified")
 	}
 
 	rp := proxy.NewHTTPReverseProxy(
@@ -234,7 +243,7 @@ func (s *Service) Playwright(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	podIP, sessionUUID, ok := s.createBrowser(rw, req, name, version, opts, writePlaywrightWaitError)
+	podIP, browserHostname, sessionUUID, ok := s.createBrowser(rw, req, name, version, opts, writePlaywrightWaitError)
 	if !ok {
 		return
 	}
@@ -253,7 +262,11 @@ func (s *Service) Playwright(rw http.ResponseWriter, req *http.Request) {
 		return url, nil
 	}
 
-	log.Info().Str("ip", podIP).Msg("proxying playwright request")
+	log.Info().
+		Dict("Browser", zerolog.Dict().
+			Str("ip", podIP).
+			Str("hostname", browserHostname)).
+		Msg("proxying playwright request")
 
 	rp := proxy.NewWebSocketReverseProxy(resolver)
 	rp.ServeHTTP(rw, req)
@@ -276,19 +289,25 @@ func (s *Service) RouteHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	ip, err := parseSessionID(sessionId)
+	podIp, err := parseSessionID(sessionId)
 	if err != nil {
 		log.Error().Msg("invalid url param: sessionId")
 		http.Error(rw, "invalid url param: sessionId", http.StatusBadRequest)
 		return
 	}
 
+	log = log.With().
+		Dict("Browser", zerolog.Dict().
+			Str("ip", podIp.String())).
+		Str("sessionId", sessionId).
+		Logger()
+
 	reqModifier := func(r *http.Request) {
 		r.URL.Scheme = "http"
-		r.URL.Host = s.sidecarHost(ip.String())
+		r.URL.Host = s.sidecarHost(podIp.String())
 		r.URL.Path = path.Clean(req.URL.Path)
 
-		log.Info().Str("sessionId", sessionId).Str("ip", ip.String()).Msg("http proxy request modified")
+		log.Info().Msg("http proxy request modified")
 	}
 
 	log.Info().Msg("proxying http proxy request")
@@ -321,14 +340,18 @@ func (s *Service) McpHandler(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		podIP, _, ok := s.createBrowser(rw, req, name, version, selenosisOpts, writeMcpWaitError)
+		podIP, browserHostname, _, ok := s.createBrowser(rw, req, name, version, selenosisOpts, writeMcpWaitError)
 		if !ok {
 			return
 		}
 
 		host := s.sidecarHost(podIP)
 
-		log.Info().Str("ip", podIP).Msg("proxying mcp initialize request")
+		log.Info().
+			Dict("Browser", zerolog.Dict().
+				Str("ip", podIP).
+				Str("hostname", browserHostname)).
+			Msg("proxying mcp initialize request")
 
 		reqModifier := func(r *http.Request) {
 			r.URL = &url.URL{
@@ -354,16 +377,19 @@ func (s *Service) McpHandler(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	ip, err := parseSessionID(sessionId)
+	podIp, err := parseSessionID(sessionId)
 	if err != nil {
 		log.Error().Str("mcpSessionId", sessionId).Msg("invalid Mcp-Session-Id")
 		jsonrpc.WriteError(rw, http.StatusBadRequest, jsonrpc.InvalidParams, "Bad Request: invalid Mcp-Session-Id")
 		return
 	}
 
-	host := s.sidecarHost(ip.String())
+	host := s.sidecarHost(podIp.String())
 
-	log.Info().Str("ip", ip.String()).Msg("proxying mcp request")
+	log.Info().Dict("Browser", zerolog.Dict().
+		Str("ip", podIp.String())).
+		Str("sessionId", sessionId).
+		Msg("proxying mcp request")
 
 	reqModifier := func(r *http.Request) {
 		r.URL = &url.URL{
@@ -377,17 +403,19 @@ func (s *Service) McpHandler(rw http.ResponseWriter, req *http.Request) {
 
 	rp := proxy.NewHTTPReverseProxy(
 		proxy.WithRequestModifier(reqModifier),
-		proxy.WithErrorHandler(mcpProxyErrorHandler(log, ip.String())),
+		proxy.WithErrorHandler(mcpProxyErrorHandler(log, podIp.String())),
 	)
 	rp.ServeHTTP(rw, req)
 }
 
-func (s *Service) createBrowser(rw http.ResponseWriter, req *http.Request, name, version string, opts map[string]any, writeWaitError func(http.ResponseWriter, *browserError)) (string, uuid.UUID, bool) {
+func (s *Service) createBrowser(rw http.ResponseWriter, req *http.Request, name, version string, opts map[string]any, writeWaitError func(http.ResponseWriter, *browserError)) (string, string, uuid.UUID, bool) {
 	log := logctx.FromContext(req.Context())
+
+	hostname := uuid.NewString()
 
 	template := &browserv1.Browser{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
+			Name: hostname,
 		},
 		Spec: browserv1.BrowserSpec{
 			BrowserName:    name,
@@ -401,101 +429,101 @@ func (s *Service) createBrowser(rw http.ResponseWriter, req *http.Request, name,
 		if err != nil {
 			log.Err(err).Msg("failed to set selenosis options annotation")
 			http.Error(rw, err.Error(), http.StatusBadRequest)
-			return "", uuid.UUID{}, false
+			return "", "", uuid.UUID{}, false
 		}
 	}
 
 	setOwnerReference(req.Context(), template)
+	setHubLabel(req, template)
 
 	log = log.With().
-		Str("browserName", template.Spec.BrowserName).
-		Str("browserVersion", template.Spec.BrowserVersion).
-		Str("namespace", s.config.Namespace).
+		Dict("Browser", zerolog.Dict().
+			Str("hostname", hostname).
+			Str("type", template.Spec.BrowserName).
+			Str("version", template.Spec.BrowserVersion)).
 		Logger()
 
 	ctx, cancel := context.WithTimeout(req.Context(), s.config.BrowserStartTimeout)
 	defer cancel()
 
-	_, podIP, waitErr := s.createBrowserAndWait(ctx, log, template)
+	podIP, waitErr := s.createBrowserAndWait(ctx, log, template)
 	if waitErr != nil {
 		writeWaitError(rw, waitErr)
-		return "", uuid.UUID{}, false
+		return "", "", uuid.UUID{}, false
 	}
 
-	ip := net.ParseIP(podIP)
-	if ip == nil {
+	podIp := net.ParseIP(podIP)
+	if podIp == nil {
 		log.Err(fmt.Errorf("invalid pod IP: %s", podIP)).Msg("failed to parse pod IP")
 		http.Error(rw, "failed to get browser IP", http.StatusInternalServerError)
-		return "", uuid.UUID{}, false
+		return "", "", uuid.UUID{}, false
 	}
 
-	sessionUUID, err := ipuuid.IPToUUID(ip)
+	sessionUUID, err := ipuuid.IPToUUID(podIp)
 	if err != nil {
 		log.Err(err).Str("podIP", podIP).Msg("failed to convert IP to UUID")
 		http.Error(rw, "failed to convert IP to UUID", http.StatusInternalServerError)
-		return "", uuid.UUID{}, false
+		return "", "", uuid.UUID{}, false
 	}
 
-	return podIP, sessionUUID, true
+	return podIP, hostname, sessionUUID, true
 }
 
-func (s *Service) createBrowserAndWait(ctx context.Context, logger zerolog.Logger, template *browserv1.Browser) (string, string, *browserError) {
+func (s *Service) createBrowserAndWait(ctx context.Context, logger zerolog.Logger, template *browserv1.Browser) (string, *browserError) {
 	logger.Info().Msg("creating browser resource")
 
 	stream, err := s.client.Events(ctx, s.config.Namespace, browserclient.WithName(template.GetName()))
 	if err != nil {
-		logger.Err(err).Str("name", template.GetName()).Msg("failed to start browser event stream")
-		return template.GetName(), "", &browserError{kind: browserEventsStart, err: err}
+		logger.Err(err).Msg("failed to start browser event stream")
+		return "", &browserError{kind: browserEventsStart, err: err}
 	}
 	defer stream.Close()
 
-	result, err := s.client.Create(ctx, s.config.Namespace, template)
-	if err != nil {
+	if _, err := s.client.Create(ctx, s.config.Namespace, template); err != nil {
 		logger.Err(err).Msg("failed to create browser resource")
-		return "", "", &browserError{kind: browserCreate, err: err}
+		return "", &browserError{kind: browserCreate, err: err}
 	}
 
-	browserName := result.GetName()
-	logger.Info().Str("name", browserName).Msg("waiting for browser to become ready")
+	logger.Info().Msg("waiting for browser to become ready")
 
 	for {
 		select {
 		case event, ok := <-stream.Events():
 			if !ok {
-				logger.Error().Str("name", browserName).Msg("browser event stream closed unexpectedly")
-				return browserName, "", &browserError{kind: browserStreamClosed}
+				logger.Error().Msg("browser event stream closed unexpectedly")
+				return "", &browserError{kind: browserStreamClosed}
 			}
 
 			if event.Browser == nil {
-				logger.Warn().Str("name", browserName).Msg("received browser event with nil browser")
+				logger.Warn().Msg("received browser event with nil browser")
 				continue
 			}
 
 			switch event.Browser.Status.Phase {
 			case "Failed":
-				logger.Error().Str("name", browserName).Str("statusReason", event.Browser.Status.Reason).Msg("browser failed to start")
-				return browserName, "", &browserError{kind: browserFailed}
+				logger.Error().Str("statusReason", event.Browser.Status.Reason).Msg("browser failed to start")
+				return "", &browserError{kind: browserFailed}
 
 			case "Running":
 				podIP := event.Browser.Status.PodIP
-				logger.Info().Str("name", browserName).Msg("browser successfully started")
-				return browserName, podIP, nil
+				logger.Info().Msg("browser successfully started")
+				return podIP, nil
 			}
 
 		case err, ok := <-stream.Errors():
 			if !ok {
-				logger.Error().Str("name", browserName).Msg("browser error stream closed unexpectedly")
-				return browserName, "", &browserError{kind: browserStreamClosed}
+				logger.Error().Msg("browser error stream closed unexpectedly")
+				return "", &browserError{kind: browserStreamClosed}
 			}
 
 			if err != nil {
-				logger.Err(err).Str("name", browserName).Msg("browser event stream error")
-				return browserName, "", &browserError{kind: browserStreamError, err: err}
+				logger.Err(err).Msg("browser event stream error")
+				return "", &browserError{kind: browserStreamError, err: err}
 			}
 
 		case <-ctx.Done():
-			logger.Info().Str("name", browserName).Msg("context cancelled, stopping browser event stream")
-			return browserName, "", &browserError{kind: browserContextDone}
+			logger.Info().Msg("context cancelled, stopping browser event stream")
+			return "", &browserError{kind: browserContextDone}
 		}
 	}
 }
@@ -541,4 +569,17 @@ func externalBaseURL(r *http.Request) *url.URL {
 		Scheme: proto,
 		Host:   host,
 	}
+}
+
+func setHubLabel(req *http.Request, template *browserv1.Browser) {
+	hostname := req.Header.Get("X-Selenosis-Hostname")
+	if hostname == "" {
+		return
+	}
+
+	if template.ObjectMeta.Labels == nil {
+		template.ObjectMeta.Labels = map[string]string{}
+	}
+
+	template.ObjectMeta.Labels[browserv1.SelenosisHubLabelKey] = hostname
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1060,11 +1060,52 @@ func TestCreateBrowserSetOptionsError(t *testing.T) {
 	rw := httptest.NewRecorder()
 
 	opts := map[string]any{"bad": make(chan int)}
-	if _, _, ok := svc.createBrowser(rw, req, "chromium", "123", opts, writeMcpWaitError); ok {
+	if _, _, _, ok := svc.createBrowser(rw, req, "chromium", "123", opts, writeMcpWaitError); ok {
 		t.Fatal("expected createBrowser to fail on unmarshalable options")
 	}
 	if rw.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", rw.Code)
+	}
+}
+
+func TestCreateBrowserReturnsBrowserNameAndSessionUUID(t *testing.T) {
+	stream := newFakeStream()
+	stream.events <- &event.BrowserEvent{
+		Browser: &browserv1.Browser{
+			Status: browserv1.BrowserStatus{Phase: "Running", PodIP: "127.0.0.1"},
+		},
+	}
+	cc := &captureClient{fakeClient: fakeClient{stream: stream}}
+	svc := NewService(cc, ServiceConfig{Namespace: "ns", SidecarPort: "4444", BrowserStartTimeout: time.Second})
+	req := httptest.NewRequest(http.MethodPost, "/session", nil)
+	rw := httptest.NewRecorder()
+
+	podIP, browserName, sessionUUID, ok := svc.createBrowser(rw, req, "chromium", "123", nil, writeCreateSessionWaitError)
+	if !ok {
+		t.Fatalf("expected createBrowser to succeed, status=%d", rw.Code)
+	}
+	if podIP != "127.0.0.1" {
+		t.Errorf("podIP = %q, want 127.0.0.1", podIP)
+	}
+	if cc.created == nil {
+		t.Fatal("expected browser to be created")
+	}
+	if browserName == "" {
+		t.Error("browserName is empty, want generated CR name")
+	}
+	if browserName != cc.created.GetName() {
+		t.Errorf("browserName = %q, want CR name %q", browserName, cc.created.GetName())
+	}
+
+	wantUUID, err := ipuuid.IPToUUID(net.ParseIP("127.0.0.1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessionUUID != wantUUID {
+		t.Errorf("sessionUUID = %s, want ipuuid of pod IP %s", sessionUUID, wantUUID)
+	}
+	if browserName == sessionUUID.String() {
+		t.Error("browserName (CR name) must not equal sessionUUID (pod-IP encoding)")
 	}
 }
 


### PR DESCRIPTION
 Summary — Adds hub-instance provenance (header + Browser label) and nested structured logging; renames the request-id header to the X- convention.

https://github.com/alcounit/selenosis/issues/75