### PR TITLE
feat: Build multi-arch (linux/amd64 + linux/arm64) container images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           VERSION: ${{ steps.meta.outputs.version }}
-          PLATFORM: linux/amd64
+          PLATFORM: linux/amd64,linux/arm64
           EXTRA_TAGS: -t ${{ secrets.REGISTRY }}/selenosis:latest
         run: |
           make deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 
-FROM golang:1.25.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.0 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /src
 
@@ -8,11 +11,7 @@ RUN go mod download
 
 COPY . .
 
-ENV CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64
-
-RUN go build \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -trimpath \
     -ldflags="-s -w" \
     -o /out/selenosis \


### PR DESCRIPTION
Adds support for `linux/arm64`.

Args `TARGETOS` and `TARGETARCH` are automatically populated when using `--platform`. ([reference](https://docs.docker.com/build/building/multi-platform/#cross-compiling-a-go-application))

Resolves #77