### PR TITLE
Retry a failed dial on session create and report why a browser never started

### DIFF
--- a/cmd/selenosis/main.go
+++ b/cmd/selenosis/main.go
@@ -168,6 +168,7 @@ func loadConfig() (service.ServiceConfig, *auth.AuthStore, string, string, error
 
 	cfg.SidecarPort = env.GetEnvOrDefault("PROXY_PORT", "4445")
 	cfg.BrowserStartTimeout = env.GetEnvDurationOrDefault("BROWSER_STARTUP_TIMEOUT", 3*time.Minute)
+	cfg.SessionCreateTimeout = env.GetEnvDurationOrDefault("SESSION_CREATE_TIMEOUT", 3*time.Minute)
 	cfg.Namespace = env.GetEnvOrDefault("NAMESPACE", "selenosis")
 
 	basicAuthFilePath := env.GetEnvOrDefault("BASIC_AUTH_FILE", "")

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/rs/zerolog v1.34.0
+	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 )
 
@@ -29,7 +30,6 @@ require (
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/api v0.35.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/pkg/proxy/dial_retry_test.go
+++ b/pkg/proxy/dial_retry_test.go
@@ -1,0 +1,605 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func refusedErr() error {
+	return &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED}
+}
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString("ok")),
+		Header:     make(http.Header),
+	}
+}
+
+func upstreamModifier(r *http.Request) {
+	r.URL.Scheme = "http"
+	r.URL.Host = "upstream.test"
+}
+
+func bodyModifier(body []byte) RequestModifier {
+	return func(r *http.Request) {
+		upstreamModifier(r)
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		r.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(body)), nil
+		}
+		r.ContentLength = int64(len(body))
+	}
+}
+
+func TestDialRetrySucceedsAfterRefusals(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			return nil, refusedErr()
+		}
+		return okResponse(), nil
+	})
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(upstreamModifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: 5 * time.Second}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	rw := httptest.NewRecorder()
+	rp.ServeHTTP(rw, req)
+
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Fatalf("expected 3 attempts, got %d", got)
+	}
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+}
+
+func TestDialRetryKeepsTryingWithinBudget(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, refusedErr()
+	})
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(upstreamModifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: 500 * time.Millisecond, Interval: 10 * time.Millisecond}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	rp.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := atomic.LoadInt32(&attempts); got < 5 {
+		t.Fatalf("expected the budget to allow several attempts, got %d", got)
+	}
+}
+
+func TestDialRetryIntervalDefaultsWhenUnset(t *testing.T) {
+	rp := NewHTTPReverseProxy(WithHTTPDialRetry(DialRetry{Timeout: time.Minute}))
+
+	rt, ok := rp.rp.Transport.(*dialRetryTransport)
+	if !ok {
+		t.Fatalf("expected the transport to be wrapped, got %T", rp.rp.Transport)
+	}
+	if rt.interval != DefaultDialRetryInterval {
+		t.Fatalf("interval = %v, want %v", rt.interval, DefaultDialRetryInterval)
+	}
+}
+
+func TestDialRetryIntervalOverride(t *testing.T) {
+	rp := NewHTTPReverseProxy(
+		WithHTTPDialRetry(DialRetry{Timeout: time.Minute, Interval: 25 * time.Millisecond}),
+	)
+
+	rt, ok := rp.rp.Transport.(*dialRetryTransport)
+	if !ok {
+		t.Fatalf("expected the transport to be wrapped, got %T", rp.rp.Transport)
+	}
+	if rt.interval != 25*time.Millisecond {
+		t.Fatalf("interval = %v, want 25ms", rt.interval)
+	}
+}
+
+func TestDialRetryIntervalFallsBackOnNonPositive(t *testing.T) {
+	rp := NewHTTPReverseProxy(
+		WithHTTPDialRetry(DialRetry{Timeout: time.Minute, Interval: 0}),
+	)
+
+	rt, ok := rp.rp.Transport.(*dialRetryTransport)
+	if !ok {
+		t.Fatalf("expected the transport to be wrapped, got %T", rp.rp.Transport)
+	}
+	if rt.interval != DefaultDialRetryInterval {
+		t.Fatalf("interval = %v, want %v", rt.interval, DefaultDialRetryInterval)
+	}
+}
+
+func TestDialRetryIntervalWithoutTimeoutLeavesTransportUnwrapped(t *testing.T) {
+	rp := NewHTTPReverseProxy(WithHTTPDialRetry(DialRetry{Interval: 25 * time.Millisecond}))
+
+	if _, ok := rp.rp.Transport.(*dialRetryTransport); ok {
+		t.Fatal("expected no retry wrapper when the budget is not set")
+	}
+}
+
+func TestDialRetryStopsAtDeadline(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, refusedErr()
+	})
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(upstreamModifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: 300 * time.Millisecond}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	rw := httptest.NewRecorder()
+
+	start := time.Now()
+	rp.ServeHTTP(rw, req)
+	elapsed := time.Since(start)
+
+	if got := atomic.LoadInt32(&attempts); got < 2 {
+		t.Fatalf("expected the dial to be retried, got %d attempts", got)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("deadline did not stop the loop: took %v", elapsed)
+	}
+}
+
+func TestDialRetryIgnoresOtherErrors(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, errors.New("boom")
+	})
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(upstreamModifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: time.Minute}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	rp.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected no retry for a non-refused error, got %d attempts", got)
+	}
+}
+
+func TestDialRetryStopsOnCancelledContext(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, refusedErr()
+	})
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(upstreamModifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: 10 * time.Second}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil).WithContext(ctx)
+
+	start := time.Now()
+	rp.ServeHTTP(httptest.NewRecorder(), req)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("cancelled context did not stop the loop: took %v", elapsed)
+	}
+	if got := atomic.LoadInt32(&attempts); got > 2 {
+		t.Fatalf("expected at most 2 attempts on a cancelled context, got %d", got)
+	}
+}
+
+func TestDialRetryReplaysRequestBody(t *testing.T) {
+	payload := []byte(`{"capabilities":{}}`)
+
+	var attempts int32
+	var seen []string
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("failed to read body: %v", err)
+		}
+		seen = append(seen, string(body))
+
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			return nil, refusedErr()
+		}
+		return okResponse(), nil
+	})
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(bodyModifier(payload)),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: 5 * time.Second}),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/session", bytes.NewReader(payload))
+	rp.ServeHTTP(httptest.NewRecorder(), req)
+
+	if len(seen) != 3 {
+		t.Fatalf("expected 3 attempts, got %d", len(seen))
+	}
+	for i, got := range seen {
+		if got != string(payload) {
+			t.Fatalf("attempt %d proxied body %q, want %q", i+1, got, payload)
+		}
+	}
+}
+
+func TestDialRetrySkippedWhenBodyIsNotReplayable(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, refusedErr()
+	})
+
+	modifier := func(r *http.Request) {
+		upstreamModifier(r)
+		r.Body = io.NopCloser(bytes.NewBufferString("payload"))
+		r.GetBody = nil
+		r.ContentLength = int64(len("payload"))
+	}
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(modifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: time.Minute}),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/session", bytes.NewBufferString("payload"))
+	rp.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected no retry without GetBody, got %d attempts", got)
+	}
+}
+
+func TestWithoutDialRetryDialsOnce(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, refusedErr()
+	})
+
+	rp := NewHTTPReverseProxy(WithRequestModifier(upstreamModifier), WithTransport(rt))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	rp.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected exactly 1 attempt without the option, got %d", got)
+	}
+}
+
+func TestDialRetryHonoursTransportSetAfterOption(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if atomic.AddInt32(&attempts, 1) < 2 {
+			return nil, refusedErr()
+		}
+		return okResponse(), nil
+	})
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(upstreamModifier),
+		WithHTTPDialRetry(DialRetry{Timeout: 5 * time.Second}),
+		WithTransport(rt),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	rw := httptest.NewRecorder()
+	rp.ServeHTTP(rw, req)
+
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("expected the option to wrap a transport set after it, got %d attempts", got)
+	}
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+}
+
+func TestIsDialError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"refused", refusedErr(), true},
+		{"host unreachable", &net.OpError{Op: "dial", Net: "tcp", Err: syscall.EHOSTUNREACH}, true},
+		{"network unreachable", &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ENETUNREACH}, true},
+		{"dial timeout", &net.OpError{Op: "dial", Net: "tcp", Err: context.DeadlineExceeded}, true},
+		{"wrapped dial", fmt.Errorf("proxy: %w", refusedErr()), true},
+		{"read reset", &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}, false},
+		{"read timeout", &net.OpError{Op: "read", Net: "tcp", Err: os.ErrDeadlineExceeded}, false},
+		{"bare errno", syscall.ECONNREFUSED, false},
+		{"eof", io.EOF, false},
+		{"plain", errors.New("boom"), false},
+		{"nil", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDialError(tt.err); got != tt.want {
+				t.Fatalf("isDialError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDialRetryRetriesUnreachableAndTimeout(t *testing.T) {
+	errs := []error{
+		&net.OpError{Op: "dial", Net: "tcp", Err: syscall.EHOSTUNREACH},
+		&net.OpError{Op: "dial", Net: "tcp", Err: context.DeadlineExceeded},
+	}
+
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		n := atomic.AddInt32(&attempts, 1)
+		if int(n) <= len(errs) {
+			return nil, errs[n-1]
+		}
+		return okResponse(), nil
+	})
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(upstreamModifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: 5 * time.Second, Interval: time.Millisecond}),
+	)
+
+	rw := httptest.NewRecorder()
+	rp.ServeHTTP(rw, httptest.NewRequest(http.MethodGet, "http://example.com/", nil))
+
+	if got := atomic.LoadInt32(&attempts); got != int32(len(errs))+1 {
+		t.Fatalf("expected %d attempts, got %d", len(errs)+1, got)
+	}
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+}
+
+func TestDialRetrySkippedForNonDialErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"eof", io.EOF},
+		{"read reset", &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempts int32
+			rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				atomic.AddInt32(&attempts, 1)
+				return nil, tt.err
+			})
+
+			rp := NewHTTPReverseProxy(
+				WithRequestModifier(upstreamModifier),
+				WithTransport(rt),
+				WithHTTPDialRetry(DialRetry{Timeout: 5 * time.Second, Interval: time.Millisecond}),
+			)
+
+			rw := httptest.NewRecorder()
+			rp.ServeHTTP(rw, httptest.NewRequest(http.MethodGet, "http://example.com/", nil))
+
+			if got := atomic.LoadInt32(&attempts); got != 1 {
+				t.Fatalf("expected a single attempt, got %d", got)
+			}
+		})
+	}
+}
+
+func TestReplayable(t *testing.T) {
+	withBody := httptest.NewRequest(http.MethodPost, "http://example.com/", bytes.NewBufferString("x"))
+	withBody.GetBody = nil
+
+	replayableBody := httptest.NewRequest(http.MethodPost, "http://example.com/", bytes.NewBufferString("x"))
+	replayableBody.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewBufferString("x")), nil
+	}
+
+	noBody := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	noBody.Body = nil
+
+	tests := []struct {
+		name string
+		req  *http.Request
+		want bool
+	}{
+		{"nil body", noBody, true},
+		{"body with GetBody", replayableBody, true},
+		{"body without GetBody", withBody, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := replayable(tt.req); got != tt.want {
+				t.Fatalf("replayable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDialRetryReturnsErrorWhenGetBodyFails(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, refusedErr()
+	})
+
+	modifier := func(r *http.Request) {
+		upstreamModifier(r)
+		r.Body = io.NopCloser(bytes.NewBufferString("payload"))
+		r.GetBody = func() (io.ReadCloser, error) {
+			return nil, errors.New("rewind failed")
+		}
+		r.ContentLength = int64(len("payload"))
+	}
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(modifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: time.Minute}),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/session", bytes.NewBufferString("payload"))
+	rp.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected the loop to stop when GetBody fails, got %d attempts", got)
+	}
+}
+
+func BenchmarkHTTPReverseProxy(b *testing.B) {
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return okResponse(), nil
+	})
+	rp := NewHTTPReverseProxy(WithRequestModifier(upstreamModifier), WithTransport(rt))
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		rp.ServeHTTP(httptest.NewRecorder(), req)
+	}
+}
+
+func BenchmarkHTTPReverseProxyWithHTTPDialRetry(b *testing.B) {
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return okResponse(), nil
+	})
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(upstreamModifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: time.Minute}),
+	)
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		rp.ServeHTTP(httptest.NewRecorder(), req)
+	}
+}
+
+func TestDialRetryStopsWhenRetryHitsAnotherError(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			return nil, refusedErr()
+		}
+		return nil, errors.New("boom")
+	})
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(upstreamModifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: time.Minute}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	rp.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("expected the loop to stop on a non-refused error, got %d attempts", got)
+	}
+}
+
+func TestDialRetryMaxIntervalWiring(t *testing.T) {
+	rp := NewHTTPReverseProxy(
+		WithHTTPDialRetry(DialRetry{Timeout: time.Minute, Interval: 50 * time.Millisecond, MaxInterval: 500 * time.Millisecond}),
+	)
+
+	rt, ok := rp.rp.Transport.(*dialRetryTransport)
+	if !ok {
+		t.Fatalf("expected the transport to be wrapped, got %T", rp.rp.Transport)
+	}
+	if rt.interval != 50*time.Millisecond {
+		t.Fatalf("interval = %v, want 50ms", rt.interval)
+	}
+	if rt.maxInterval != 500*time.Millisecond {
+		t.Fatalf("maxInterval = %v, want 500ms", rt.maxInterval)
+	}
+}
+
+func TestDialRetryBackoffSlowsDownRetries(t *testing.T) {
+	count := func(opts ...HTTPReverseProxyOptions) int32 {
+		var attempts int32
+		rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return nil, refusedErr()
+		})
+
+		opts = append(opts, WithRequestModifier(upstreamModifier), WithTransport(rt))
+		rp := NewHTTPReverseProxy(opts...)
+
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+		rp.ServeHTTP(httptest.NewRecorder(), req)
+
+		return atomic.LoadInt32(&attempts)
+	}
+
+	flat := count(
+		WithHTTPDialRetry(DialRetry{Timeout: 400 * time.Millisecond, Interval: 10 * time.Millisecond}),
+	)
+	backoff := count(
+		WithHTTPDialRetry(DialRetry{Timeout: 400 * time.Millisecond, Interval: 10 * time.Millisecond, MaxInterval: 160 * time.Millisecond}),
+	)
+
+	if backoff >= flat {
+		t.Fatalf("expected backoff to make fewer attempts than a flat interval, got %d vs %d", backoff, flat)
+	}
+}
+
+func TestDialRetryMaxIntervalBelowIntervalStaysFlat(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, refusedErr()
+	})
+
+	rp := NewHTTPReverseProxy(
+		WithRequestModifier(upstreamModifier),
+		WithTransport(rt),
+		WithHTTPDialRetry(DialRetry{Timeout: 300 * time.Millisecond, Interval: 20 * time.Millisecond, MaxInterval: 5 * time.Millisecond}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	rp.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := atomic.LoadInt32(&attempts); got < 5 {
+		t.Fatalf("expected a flat interval to keep retrying, got %d attempts", got)
+	}
+}

--- a/pkg/proxy/http_proxy.go
+++ b/pkg/proxy/http_proxy.go
@@ -1,10 +1,13 @@
 package proxy
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"time"
+
+	logctx "github.com/alcounit/browser-controller/pkg/log"
 )
 
 var DefaultTransport http.RoundTripper = &http.Transport{
@@ -17,6 +20,98 @@ var DefaultTransport http.RoundTripper = &http.Transport{
 	TLSHandshakeTimeout: 10 * time.Second,
 }
 
+const DefaultDialRetryInterval = 100 * time.Millisecond
+
+type dialRetryTransport struct {
+	base        http.RoundTripper
+	timeout     time.Duration
+	interval    time.Duration
+	maxInterval time.Duration
+}
+
+func isDialError(err error) bool {
+	var oe *net.OpError
+	return errors.As(err, &oe) && oe.Op == "dial"
+}
+
+func replayable(req *http.Request) bool {
+	return req.Body == nil || req.Body == http.NoBody || req.GetBody != nil
+}
+
+func (t *dialRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err == nil || !isDialError(err) || !replayable(req) {
+		return resp, err
+	}
+
+	log := logctx.FromContext(req.Context())
+	start := time.Now()
+	deadline := start.Add(t.timeout)
+	ctx := req.Context()
+
+	delay := t.interval
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	attempt := 1
+
+	giveUp := func(reason string) (*http.Response, error) {
+		log.Warn().Err(err).
+			Str("reason", reason).
+			Int("attempts", attempt).
+			Dur("elapsed", time.Since(start)).
+			Dur("timeout", t.timeout).
+			Dur("interval", t.interval).
+			Dur("maxInterval", t.maxInterval).
+			Str("host", req.URL.Host).
+			Msg("upstream dial keeps failing, giving up")
+		return resp, err
+	}
+
+	for ; ; attempt++ {
+		if !time.Now().Before(deadline) {
+			return giveUp("deadline")
+		}
+
+		select {
+		case <-ctx.Done():
+			return giveUp("client-cancelled")
+		case <-timer.C:
+		}
+
+		if t.maxInterval > delay {
+			delay = min(delay*2, t.maxInterval)
+		}
+		timer.Reset(delay)
+
+		retry := req.Clone(ctx)
+		if req.GetBody != nil {
+			body, berr := req.GetBody()
+			if berr != nil {
+				return resp, err
+			}
+			retry.Body = body
+		}
+
+		resp, err = t.base.RoundTrip(retry)
+		if err == nil {
+			log.Info().
+				Int("attempts", attempt+1).
+				Dur("elapsed", time.Since(start)).
+				Dur("timeout", t.timeout).
+				Dur("interval", t.interval).
+				Dur("maxInterval", t.maxInterval).
+				Str("host", req.URL.Host).
+				Msg("upstream reachable after dial retry")
+			return resp, nil
+		}
+
+		if !isDialError(err) {
+			return resp, err
+		}
+	}
+}
+
 type RequestModifier func(*http.Request)
 
 type ResponseModifier func(*http.Response) error
@@ -26,6 +121,8 @@ type ErrorHandler func(w http.ResponseWriter, r *http.Request, err error)
 type HTTPReverseProxy struct {
 	rp              *httputil.ReverseProxy
 	requestModifier RequestModifier
+
+	dialRetry DialRetry
 }
 
 type HTTPReverseProxyOptions func(*HTTPReverseProxy)
@@ -54,6 +151,18 @@ func WithErrorHandler(errHandler ErrorHandler) HTTPReverseProxyOptions {
 	}
 }
 
+type DialRetry struct {
+	Timeout     time.Duration
+	Interval    time.Duration
+	MaxInterval time.Duration
+}
+
+func WithHTTPDialRetry(retry DialRetry) HTTPReverseProxyOptions {
+	return func(p *HTTPReverseProxy) {
+		p.dialRetry = retry
+	}
+}
+
 func NewHTTPReverseProxy(opts ...HTTPReverseProxyOptions) *HTTPReverseProxy {
 	proxy := HTTPReverseProxy{
 		rp: &httputil.ReverseProxy{
@@ -65,6 +174,20 @@ func NewHTTPReverseProxy(opts ...HTTPReverseProxyOptions) *HTTPReverseProxy {
 
 	for _, opt := range opts {
 		opt(&proxy)
+	}
+
+	if proxy.dialRetry.Timeout > 0 {
+		interval := proxy.dialRetry.Interval
+		if interval <= 0 {
+			interval = DefaultDialRetryInterval
+		}
+
+		proxy.rp.Transport = &dialRetryTransport{
+			base:        proxy.rp.Transport,
+			timeout:     proxy.dialRetry.Timeout,
+			interval:    interval,
+			maxInterval: proxy.dialRetry.MaxInterval,
+		}
 	}
 
 	proxy.rp.Rewrite = func(pr *httputil.ProxyRequest) {

--- a/pkg/proxy/ws_proxy.go
+++ b/pkg/proxy/ws_proxy.go
@@ -29,10 +29,9 @@ func WithOnClose(f func()) WSProxyOption {
 	return func(p *WSProxy) { p.onClose = f }
 }
 
-func WithRetryTimeout(timeout time.Duration) WSProxyOption {
+func WithWSDialRetry(retry DialRetry) WSProxyOption {
 	return func(p *WSProxy) {
-		p.dialRetryEnabled = true
-		p.timeout = timeout
+		p.dialRetry = retry
 	}
 }
 
@@ -41,8 +40,7 @@ type WSProxy struct {
 	Dialer   websocket.Dialer
 	Resolve  TargetResolver
 
-	dialRetryEnabled bool
-	timeout          time.Duration
+	dialRetry DialRetry
 
 	onConnect func()
 	onMessage func()
@@ -57,7 +55,6 @@ func NewWebSocketReverseProxy(resolver TargetResolver, opts ...WSProxyOption) *W
 				return true
 			},
 		},
-		dialRetryEnabled: false,
 		Dialer: websocket.Dialer{
 			Proxy:            http.ProxyFromEnvironment,
 			HandshakeTimeout: 10 * time.Second,
@@ -98,8 +95,8 @@ func (p *WSProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	upstreamHeaders.Set("Host", targetURL.Host)
 	upstreamHeaders.Del("Origin")
 
-	if p.dialRetryEnabled {
-		upstreamConn, resp, err = dialWithWait(r.Context(), targetURL.String(), &p.Dialer, upstreamHeaders, p.timeout)
+	if p.dialRetry.Timeout > 0 {
+		upstreamConn, resp, err = dialWithWait(r.Context(), targetURL.String(), &p.Dialer, upstreamHeaders, p.dialRetry)
 	} else {
 		upstreamConn, resp, err = p.Dialer.DialContext(r.Context(), targetURL.String(), upstreamHeaders)
 	}
@@ -256,12 +253,17 @@ func filterUpgradeResponseHeaders(src http.Header) http.Header {
 	return dst
 }
 
-func dialWithWait(ctx context.Context, target string, dialer *websocket.Dialer, headers http.Header, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+func dialWithWait(ctx context.Context, target string, dialer *websocket.Dialer, headers http.Header, retry DialRetry) (*websocket.Conn, *http.Response, error) {
+	ctx, cancel := context.WithTimeout(ctx, retry.Timeout)
 	defer cancel()
 
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
+	delay := retry.Interval
+	if delay <= 0 {
+		delay = DefaultDialRetryInterval
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
 
 	for {
 		conn, resp, err := dialer.DialContext(ctx, target, headers)
@@ -269,11 +271,19 @@ func dialWithWait(ctx context.Context, target string, dialer *websocket.Dialer, 
 			return conn, resp, nil
 		}
 
+		if !isDialError(err) {
+			return nil, resp, err
+		}
+
 		select {
 		case <-ctx.Done():
-			return nil, resp, fmt.Errorf("could not connect to %s after %v: %w", target, timeout, err)
-		case <-ticker.C:
-			continue
+			return nil, resp, fmt.Errorf("could not connect to %s after %v: %w", target, retry.Timeout, err)
+		case <-timer.C:
 		}
+
+		if retry.MaxInterval > delay {
+			delay = min(delay*2, retry.MaxInterval)
+		}
+		timer.Reset(delay)
 	}
 }

--- a/pkg/proxy/ws_proxy_test.go
+++ b/pkg/proxy/ws_proxy_test.go
@@ -165,16 +165,13 @@ func TestFilterUpgradeResponseHeaders(t *testing.T) {
 	}
 }
 
-func TestWithRetryTimeoutOption(t *testing.T) {
+func TestWithoutWSDialRetryDialsOnce(t *testing.T) {
 	p := NewWebSocketReverseProxy(func(r *http.Request) (*url.URL, error) {
 		return url.Parse("ws://example.com")
-	}, WithRetryTimeout(250*time.Millisecond))
+	})
 
-	if !p.dialRetryEnabled {
-		t.Fatal("expected retry to be enabled")
-	}
-	if p.timeout != 250*time.Millisecond {
-		t.Fatalf("unexpected timeout: %v", p.timeout)
+	if p.dialRetry.Timeout != 0 {
+		t.Fatalf("expected no retry budget by default, got %v", p.dialRetry.Timeout)
 	}
 }
 
@@ -207,7 +204,7 @@ func TestDialWithWaitSuccess(t *testing.T) {
 		_ = writeHandshakeResponse(serverConn)
 	}()
 
-	conn, resp, err := dialWithWait(context.Background(), "ws://upstream.test/ws", dialer, http.Header{}, time.Second)
+	conn, resp, err := dialWithWait(context.Background(), "ws://upstream.test/ws", dialer, http.Header{}, DialRetry{Timeout: time.Second})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -226,10 +223,10 @@ func TestDialWithWaitTimeout(t *testing.T) {
 	dialer := &websocket.Dialer{}
 	dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		atomic.AddInt32(&attempts, 1)
-		return nil, errors.New("dial failed")
+		return nil, refusedErr()
 	}
 
-	conn, _, err := dialWithWait(context.Background(), "ws://upstream.test/ws", dialer, http.Header{}, 250*time.Millisecond)
+	conn, _, err := dialWithWait(context.Background(), "ws://upstream.test/ws", dialer, http.Header{}, DialRetry{Timeout: 250 * time.Millisecond})
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -249,14 +246,14 @@ func TestDialWithWaitContextCancelled(t *testing.T) {
 	dialer := &websocket.Dialer{}
 	dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		atomic.AddInt32(&attempts, 1)
-		return nil, errors.New("dial failed")
+		return nil, refusedErr()
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
 	start := time.Now()
-	conn, _, err := dialWithWait(ctx, "ws://upstream.test/ws", dialer, http.Header{}, 10*time.Second)
+	conn, _, err := dialWithWait(ctx, "ws://upstream.test/ws", dialer, http.Header{}, DialRetry{Timeout: 10 * time.Second})
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -364,7 +361,7 @@ func TestWSProxyServeHTTPUpgradeErrorWithRetry(t *testing.T) {
 
 	p := NewWebSocketReverseProxy(func(r *http.Request) (*url.URL, error) {
 		return url.Parse("ws://upstream.test/ws")
-	}, WithRetryTimeout(time.Second))
+	}, WithWSDialRetry(DialRetry{Timeout: time.Second}))
 	p.Dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		return upClient, nil
 	}
@@ -548,6 +545,56 @@ func (h *hijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return h.conn, bufio.NewReadWriter(bufio.NewReader(h.conn), bufio.NewWriter(h.conn)), nil
 }
 
+func writeRejectResponse(conn net.Conn) error {
+	reader := bufio.NewReader(conn)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if strings.TrimRight(line, "\r\n") == "" {
+			break
+		}
+	}
+
+	_, err := conn.Write([]byte("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"))
+	return err
+}
+
+func TestDialWithWaitStopsOnBadHandshake(t *testing.T) {
+	var attempts int32
+	dialer := &websocket.Dialer{}
+	dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		atomic.AddInt32(&attempts, 1)
+
+		client, server := net.Pipe()
+		t.Cleanup(func() { _ = client.Close() })
+
+		go func() {
+			defer func() { _ = server.Close() }()
+			_ = writeRejectResponse(server)
+		}()
+
+		return client, nil
+	}
+
+	conn, resp, err := dialWithWait(context.Background(), "ws://upstream.test/ws", dialer, http.Header{},
+		DialRetry{Timeout: time.Second, Interval: time.Millisecond})
+
+	if !errors.Is(err, websocket.ErrBadHandshake) {
+		t.Fatalf("expected ErrBadHandshake, got %v", err)
+	}
+	if conn != nil {
+		t.Fatal("expected nil connection")
+	}
+	if resp == nil || resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected the upstream response to be returned, got %v", resp)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected a single attempt, got %d", got)
+	}
+}
+
 func writeHandshakeResponse(conn net.Conn) error {
 	reader := bufio.NewReader(conn)
 	var key string
@@ -654,4 +701,70 @@ func readFramePayload(r io.Reader) ([]byte, byte, error) {
 		}
 	}
 	return payload, opcode, nil
+}
+
+func TestWithWSDialRetryOption(t *testing.T) {
+	p := NewWebSocketReverseProxy(func(r *http.Request) (*url.URL, error) {
+		return url.Parse("ws://example.com")
+	}, WithWSDialRetry(DialRetry{
+		Timeout:     time.Minute,
+		Interval:    50 * time.Millisecond,
+		MaxInterval: 500 * time.Millisecond,
+	}))
+
+	if p.dialRetry.Timeout != time.Minute {
+		t.Fatalf("Timeout = %v, want 1m", p.dialRetry.Timeout)
+	}
+	if p.dialRetry.Interval != 50*time.Millisecond {
+		t.Fatalf("Interval = %v, want 50ms", p.dialRetry.Interval)
+	}
+	if p.dialRetry.MaxInterval != 500*time.Millisecond {
+		t.Fatalf("MaxInterval = %v, want 500ms", p.dialRetry.MaxInterval)
+	}
+}
+
+func TestDialWithWaitBackoffSlowsDownRetries(t *testing.T) {
+	count := func(retry DialRetry) int32 {
+		var attempts int32
+		dialer := &websocket.Dialer{}
+		dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			atomic.AddInt32(&attempts, 1)
+			return nil, refusedErr()
+		}
+
+		_, _, _ = dialWithWait(context.Background(), "ws://upstream.test/ws", dialer, http.Header{}, retry)
+		return atomic.LoadInt32(&attempts)
+	}
+
+	flat := count(DialRetry{Timeout: 400 * time.Millisecond, Interval: 10 * time.Millisecond})
+	backoff := count(DialRetry{
+		Timeout:     400 * time.Millisecond,
+		Interval:    10 * time.Millisecond,
+		MaxInterval: 160 * time.Millisecond,
+	})
+
+	if backoff >= flat {
+		t.Fatalf("expected backoff to make fewer dials than a flat interval, got %d vs %d", backoff, flat)
+	}
+}
+
+func TestDialWithWaitDefaultsIntervalWhenUnset(t *testing.T) {
+	var attempts int32
+	dialer := &websocket.Dialer{}
+	dialer.NetDialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, refusedErr()
+	}
+
+	start := time.Now()
+	_, _, err := dialWithWait(context.Background(), "ws://upstream.test/ws", dialer, http.Header{},
+		DialRetry{Timeout: 350 * time.Millisecond})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if got := atomic.LoadInt32(&attempts); got > 10 {
+		t.Fatalf("expected the default interval to pace the dials, got %d attempts in %v", got, elapsed)
+	}
 }

--- a/service/errors.go
+++ b/service/errors.go
@@ -2,9 +2,14 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"sort"
+	"strings"
+	"time"
 
+	browserv1 "github.com/alcounit/browser-controller/apis/browser/v1"
 	"github.com/alcounit/selenosis/v2/pkg/jsonrpc"
 	"github.com/alcounit/selenosis/v2/pkg/proxy"
 	"github.com/alcounit/selenosis/v2/pkg/selenium"
@@ -71,6 +76,14 @@ type browserError struct {
 	err  error
 }
 
+func (e *browserError) reason() error {
+	if e.err != nil {
+		return e.err
+	}
+
+	return ErrInternal
+}
+
 func writeCreateSessionWaitError(rw http.ResponseWriter, waitErr *browserError) {
 	switch waitErr.kind {
 	case browserCreate:
@@ -80,7 +93,9 @@ func writeCreateSessionWaitError(rw http.ResponseWriter, waitErr *browserError) 
 	case browserStreamClosed:
 		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(ErrInternal))
 	case browserFailed:
-		writeErrorResponse(rw, http.StatusInternalServerError, selenium.Error("browser failed to start", ErrInternal))
+		writeErrorResponse(rw, http.StatusInternalServerError, selenium.Error("browser failed to start", waitErr.reason()))
+	case browserNotReady:
+		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(waitErr.reason()))
 	case browserStreamError:
 		writeErrorResponse(rw, http.StatusInternalServerError, selenium.ErrUnknown(waitErr.err))
 	case browserContextDone:
@@ -99,7 +114,9 @@ func writePlaywrightWaitError(rw http.ResponseWriter, waitErr *browserError) {
 	case browserStreamClosed:
 		http.Error(rw, "browser event stream closed unexpectedly", http.StatusInternalServerError)
 	case browserFailed:
-		http.Error(rw, "browser failed to start", http.StatusInternalServerError)
+		http.Error(rw, fmt.Sprintf("browser failed to start: %s", waitErr.reason()), http.StatusInternalServerError)
+	case browserNotReady:
+		http.Error(rw, waitErr.reason().Error(), http.StatusInternalServerError)
 	case browserStreamError:
 		http.Error(rw, "browser event stream error", http.StatusInternalServerError)
 	case browserContextDone:
@@ -118,7 +135,9 @@ func writeMcpWaitError(rw http.ResponseWriter, waitErr *browserError) {
 	case browserStreamClosed:
 		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error: browser event stream closed unexpectedly")
 	case browserFailed:
-		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error: browser failed to start")
+		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, fmt.Sprintf("Internal error: browser failed to start: %s", waitErr.reason()))
+	case browserNotReady:
+		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, fmt.Sprintf("Internal error: %s", waitErr.reason()))
 	case browserStreamError:
 		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error: browser event stream error")
 	case browserContextDone:
@@ -126,4 +145,43 @@ func writeMcpWaitError(rw http.ResponseWriter, waitErr *browserError) {
 	default:
 		jsonrpc.WriteError(rw, http.StatusInternalServerError, jsonrpc.InternalError, "Internal error")
 	}
+}
+
+func browserFailure(browser *browserv1.Browser) error {
+	if msg := strings.TrimSpace(browser.Status.Message); msg != "" {
+		return errors.New(msg)
+	}
+
+	if reason := strings.TrimSpace(browser.Status.Reason); reason != "" {
+		return errors.New(reason)
+	}
+
+	return ErrInternal
+}
+
+func notReadyError(browser *browserv1.Browser, timeout time.Duration) error {
+	if browser == nil {
+		return fmt.Errorf("browser did not become ready in %v (no status received)", timeout)
+	}
+
+	waiting := make([]string, 0, len(browser.Status.ContainerStatuses))
+	for _, cs := range browser.Status.ContainerStatuses {
+		if cs.State.Waiting == nil {
+			continue
+		}
+
+		reason := cs.State.Waiting.Reason
+		if reason == "" {
+			reason = "Waiting"
+		}
+		waiting = append(waiting, fmt.Sprintf("%s: %s", cs.Name, reason))
+	}
+
+	if len(waiting) == 0 {
+		return fmt.Errorf("browser did not become ready in %v (phase %s)", timeout, browser.Status.Phase)
+	}
+
+	sort.Strings(waiting)
+
+	return fmt.Errorf("browser did not become ready in %v (%s)", timeout, strings.Join(waiting, ", "))
 }

--- a/service/service.go
+++ b/service/service.go
@@ -39,6 +39,11 @@ var (
 const (
 	maxRequestBodySize = 1 << 20 // 1 MB
 	wdHubPrefix        = "/wd/hub"
+
+	defaultRetryInitialDelay = 100 * time.Millisecond
+	defaultRetryMaxDelay     = 500 * time.Millisecond
+
+	sidecarContainerName = "seleniferous"
 )
 
 type Service struct {
@@ -47,9 +52,10 @@ type Service struct {
 }
 
 type ServiceConfig struct {
-	Namespace           string
-	SidecarPort         string
-	BrowserStartTimeout time.Duration
+	Namespace            string
+	SidecarPort          string
+	BrowserStartTimeout  time.Duration
+	SessionCreateTimeout time.Duration
 }
 
 type errorKind int
@@ -59,6 +65,7 @@ const (
 	browserEventsStart
 	browserStreamClosed
 	browserFailed
+	browserNotReady
 	browserStreamError
 	browserContextDone
 )
@@ -129,6 +136,9 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 		r.Method = req.Method
 		r.Host = r.URL.Host
 		r.Body = io.NopCloser(bytes.NewReader(body))
+		r.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(body)), nil
+		}
 		r.ContentLength = int64(len(body))
 
 		log.Info().
@@ -136,6 +146,11 @@ func (s *Service) CreateSession(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	rp := proxy.NewHTTPReverseProxy(
+		proxy.WithHTTPDialRetry(proxy.DialRetry{
+			Timeout:     s.config.SessionCreateTimeout,
+			Interval:    defaultRetryInitialDelay,
+			MaxInterval: defaultRetryMaxDelay,
+		}),
 		proxy.WithRequestModifier(reqModifier),
 		proxy.WithErrorHandler(createSessionProxyErrorHandler(log, podIP)),
 	)
@@ -268,7 +283,13 @@ func (s *Service) Playwright(rw http.ResponseWriter, req *http.Request) {
 			Str("hostname", browserHostname)).
 		Msg("proxying playwright request")
 
-	rp := proxy.NewWebSocketReverseProxy(resolver)
+	rp := proxy.NewWebSocketReverseProxy(resolver,
+		proxy.WithWSDialRetry(proxy.DialRetry{
+			Timeout:     s.config.SessionCreateTimeout,
+			Interval:    defaultRetryInitialDelay,
+			MaxInterval: defaultRetryMaxDelay,
+		}),
+	)
 	rp.ServeHTTP(rw, req)
 }
 
@@ -353,6 +374,16 @@ func (s *Service) McpHandler(rw http.ResponseWriter, req *http.Request) {
 				Str("hostname", browserHostname)).
 			Msg("proxying mcp initialize request")
 
+		var body []byte
+		if req.Body != nil {
+			defer req.Body.Close()
+			if body, err = io.ReadAll(io.LimitReader(req.Body, maxRequestBodySize)); err != nil {
+				log.Err(err).Msg("failed to read request body")
+				jsonrpc.WriteError(rw, http.StatusBadRequest, jsonrpc.InvalidParams, "Bad Request: failed to read body")
+				return
+			}
+		}
+
 		reqModifier := func(r *http.Request) {
 			r.URL = &url.URL{
 				Scheme:   "http",
@@ -361,9 +392,19 @@ func (s *Service) McpHandler(rw http.ResponseWriter, req *http.Request) {
 				RawQuery: req.URL.RawQuery,
 			}
 			r.Host = host
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			r.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(body)), nil
+			}
+			r.ContentLength = int64(len(body))
 		}
 
 		rp := proxy.NewHTTPReverseProxy(
+			proxy.WithHTTPDialRetry(proxy.DialRetry{
+				Timeout:     s.config.SessionCreateTimeout,
+				Interval:    defaultRetryInitialDelay,
+				MaxInterval: defaultRetryMaxDelay,
+			}),
 			proxy.WithRequestModifier(reqModifier),
 			proxy.WithErrorHandler(mcpInitProxyErrorHandler(log, podIP)),
 		)
@@ -486,6 +527,8 @@ func (s *Service) createBrowserAndWait(ctx context.Context, logger zerolog.Logge
 
 	logger.Info().Msg("waiting for browser to become ready")
 
+	var last *browserv1.Browser
+
 	for {
 		select {
 		case event, ok := <-stream.Events():
@@ -499,13 +542,28 @@ func (s *Service) createBrowserAndWait(ctx context.Context, logger zerolog.Logge
 				continue
 			}
 
+			last = event.Browser
+
 			switch event.Browser.Status.Phase {
 			case "Failed":
-				logger.Error().Str("statusReason", event.Browser.Status.Reason).Msg("browser failed to start")
-				return "", &browserError{kind: browserFailed}
+				err := browserFailure(event.Browser)
+				logger.Error().Err(err).
+					Str("statusReason", event.Browser.Status.Reason).
+					Str("statusMessage", event.Browser.Status.Message).
+					Msg("browser failed to start")
+				return "", &browserError{kind: browserFailed, err: err}
 
 			case "Running":
 				podIP := event.Browser.Status.PodIP
+				if podIP == "" {
+					logger.Debug().Msg("browser pod has no IP yet, waiting for next event")
+					continue
+				}
+
+				if !isContainerRunning(event.Browser, sidecarContainerName) {
+					logger.Debug().Msg("seleniferous container is not running yet, waiting for next event")
+					continue
+				}
 				logger.Info().Msg("browser successfully started")
 				return podIP, nil
 			}
@@ -522,7 +580,13 @@ func (s *Service) createBrowserAndWait(ctx context.Context, logger zerolog.Logge
 			}
 
 		case <-ctx.Done():
-			logger.Info().Msg("context cancelled, stopping browser event stream")
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				err := notReadyError(last, s.config.BrowserStartTimeout)
+				logger.Error().Err(err).Msg("browser did not become ready in time")
+				return "", &browserError{kind: browserNotReady, err: err}
+			}
+
+			logger.Info().Msg("client cancelled, stopping browser event stream")
 			return "", &browserError{kind: browserContextDone}
 		}
 	}
@@ -582,4 +646,16 @@ func setHubLabel(req *http.Request, template *browserv1.Browser) {
 	}
 
 	template.ObjectMeta.Labels[browserv1.SelenosisHubLabelKey] = hostname
+}
+
+func isContainerRunning(browser *browserv1.Browser, name string) bool {
+	if browser == nil {
+		return false
+	}
+	for i := range browser.Status.ContainerStatuses {
+		if browser.Status.ContainerStatuses[i].Name == name {
+			return browser.Status.ContainerStatuses[i].State.Running != nil
+		}
+	}
+	return false
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -25,8 +26,24 @@ import (
 	"github.com/alcounit/selenosis/v2/pkg/proxy"
 	"github.com/alcounit/selenosis/v2/pkg/selenium"
 	"github.com/go-chi/chi/v5"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func runningBrowser(podIP string) *browserv1.Browser {
+	return &browserv1.Browser{
+		Status: browserv1.BrowserStatus{
+			Phase: "Running",
+			PodIP: podIP,
+			ContainerStatuses: []browserv1.ContainerStatus{
+				{
+					Name:  sidecarContainerName,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+			},
+		},
+	}
+}
 
 func TestCreateSessionNilBody(t *testing.T) {
 	svc := NewService(&fakeClient{}, ServiceConfig{})
@@ -137,7 +154,7 @@ func TestCreateSessionFailedEvent(t *testing.T) {
 
 	svc.CreateSession(rw, req)
 
-	verifyResponseError(t, rw, http.StatusInternalServerError, selenium.Error("browser failed to start", ErrInternal))
+	verifyResponseError(t, rw, http.StatusInternalServerError, selenium.Error("browser failed to start", errors.New("nope")))
 }
 
 func TestCreateSessionEventError(t *testing.T) {
@@ -183,9 +200,7 @@ func TestCreateSessionContextDone(t *testing.T) {
 func TestCreateSessionInvalidPodIP(t *testing.T) {
 	stream := newFakeStream()
 	stream.events <- &event.BrowserEvent{
-		Browser: &browserv1.Browser{
-			Status: browserv1.BrowserStatus{Phase: "Running", PodIP: ""},
-		},
+		Browser: runningBrowser("not-an-ip"),
 	}
 
 	fc := &fakeClient{
@@ -212,12 +227,7 @@ func TestCreateSessionSuccess(t *testing.T) {
 	stream := newFakeStream()
 	stream.events <- &event.BrowserEvent{Browser: nil}
 	stream.events <- &event.BrowserEvent{
-		Browser: &browserv1.Browser{
-			Status: browserv1.BrowserStatus{
-				Phase: "Running",
-				PodIP: "127.0.0.1",
-			},
-		},
+		Browser: runningBrowser("127.0.0.1"),
 	}
 
 	fc := &fakeClient{
@@ -258,12 +268,7 @@ func TestCreateSessionSuccess(t *testing.T) {
 func TestCreateSessionUsesBrowserNameFilter(t *testing.T) {
 	stream := newFakeStream()
 	stream.events <- &event.BrowserEvent{
-		Browser: &browserv1.Browser{
-			Status: browserv1.BrowserStatus{
-				Phase: "Running",
-				PodIP: "127.0.0.1",
-			},
-		},
+		Browser: runningBrowser("127.0.0.1"),
 	}
 
 	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -299,12 +304,7 @@ func TestCreateSessionSelenosisOptionsAnnotation(t *testing.T) {
 	stream := newFakeStream()
 	stream.events <- &event.BrowserEvent{Browser: nil}
 	stream.events <- &event.BrowserEvent{
-		Browser: &browserv1.Browser{
-			Status: browserv1.BrowserStatus{
-				Phase: "Running",
-				PodIP: "127.0.0.1",
-			},
-		},
+		Browser: runningBrowser("127.0.0.1"),
 	}
 
 	var proxiedBody []byte
@@ -683,9 +683,7 @@ func TestPlaywrightContextDone(t *testing.T) {
 func TestPlaywrightInvalidPodIP(t *testing.T) {
 	stream := newFakeStream()
 	stream.events <- &event.BrowserEvent{
-		Browser: &browserv1.Browser{
-			Status: browserv1.BrowserStatus{Phase: "Running", PodIP: ""},
-		},
+		Browser: runningBrowser("not-an-ip"),
 	}
 
 	fc := &fakeClient{
@@ -717,9 +715,7 @@ func TestPlaywrightNilBrowserEventIsIgnored(t *testing.T) {
 	stream := newFakeStream()
 	stream.events <- &event.BrowserEvent{Browser: nil}
 	stream.events <- &event.BrowserEvent{
-		Browser: &browserv1.Browser{
-			Status: browserv1.BrowserStatus{Phase: "Running", PodIP: ""},
-		},
+		Browser: runningBrowser("not-an-ip"),
 	}
 
 	fc := &fakeClient{
@@ -750,9 +746,7 @@ func TestPlaywrightNilBrowserEventIsIgnored(t *testing.T) {
 func TestPlaywrightProxyAttemptAndOwnerLabel(t *testing.T) {
 	stream := newFakeStream()
 	stream.events <- &event.BrowserEvent{
-		Browser: &browserv1.Browser{
-			Status: browserv1.BrowserStatus{Phase: "Running", PodIP: "127.0.0.1"},
-		},
+		Browser: runningBrowser("127.0.0.1"),
 	}
 
 	fc := &captureClient{
@@ -805,11 +799,7 @@ func mcpSessionID(t *testing.T, ip string) string {
 
 func runningStream(podIP string) *fakeStream {
 	stream := newFakeStream()
-	stream.events <- &event.BrowserEvent{
-		Browser: &browserv1.Browser{
-			Status: browserv1.BrowserStatus{Phase: "Running", PodIP: podIP},
-		},
-	}
+	stream.events <- &event.BrowserEvent{Browser: runningBrowser(podIP)}
 	return stream
 }
 
@@ -960,7 +950,7 @@ func TestMcpHandlerInitContextDone(t *testing.T) {
 
 func TestMcpHandlerInitInvalidPodIP(t *testing.T) {
 	fc := &fakeClient{
-		stream:       runningStream(""),
+		stream:       runningStream("not-an-ip"),
 		createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
 	}
 	svc := NewService(fc, ServiceConfig{Namespace: "ns", BrowserStartTimeout: time.Second})
@@ -1071,9 +1061,7 @@ func TestCreateBrowserSetOptionsError(t *testing.T) {
 func TestCreateBrowserReturnsBrowserNameAndSessionUUID(t *testing.T) {
 	stream := newFakeStream()
 	stream.events <- &event.BrowserEvent{
-		Browser: &browserv1.Browser{
-			Status: browserv1.BrowserStatus{Phase: "Running", PodIP: "127.0.0.1"},
-		},
+		Browser: runningBrowser("127.0.0.1"),
 	}
 	cc := &captureClient{fakeClient: fakeClient{stream: stream}}
 	svc := NewService(cc, ServiceConfig{Namespace: "ns", SidecarPort: "4444", BrowserStartTimeout: time.Second})
@@ -1395,6 +1383,16 @@ func TestWriteCreateSessionWaitError(t *testing.T) {
 			expected: selenium.Error("browser failed to start", ErrInternal),
 		},
 		{
+			name:     "browser failed with reason",
+			waitErr:  &browserError{kind: browserFailed, err: errors.New("ImagePullBackOff")},
+			expected: selenium.Error("browser failed to start", errors.New("ImagePullBackOff")),
+		},
+		{
+			name:     "browser not ready",
+			waitErr:  &browserError{kind: browserNotReady, err: errors.New("not ready in 3m")},
+			expected: selenium.ErrUnknown(errors.New("not ready in 3m")),
+		},
+		{
 			name:     "stream error",
 			waitErr:  &browserError{kind: browserStreamError, err: streamErr},
 			expected: selenium.ErrUnknown(streamErr),
@@ -1443,8 +1441,13 @@ func TestWritePlaywrightWaitError(t *testing.T) {
 		},
 		{
 			name:     "browser failed",
-			waitErr:  &browserError{kind: browserFailed},
-			expected: "browser failed to start",
+			waitErr:  &browserError{kind: browserFailed, err: errors.New("ImagePullBackOff")},
+			expected: "browser failed to start: ImagePullBackOff",
+		},
+		{
+			name:     "browser not ready",
+			waitErr:  &browserError{kind: browserNotReady, err: errors.New("not ready in 3m")},
+			expected: "not ready in 3m",
 		},
 		{
 			name:     "stream error",
@@ -1500,8 +1503,13 @@ func TestWriteMcpWaitError(t *testing.T) {
 		},
 		{
 			name:     "browser failed",
-			waitErr:  &browserError{kind: browserFailed},
-			expected: "browser failed to start",
+			waitErr:  &browserError{kind: browserFailed, err: errors.New("ImagePullBackOff")},
+			expected: "browser failed to start: ImagePullBackOff",
+		},
+		{
+			name:     "browser not ready",
+			waitErr:  &browserError{kind: browserNotReady, err: errors.New("not ready in 3m")},
+			expected: "not ready in 3m",
 		},
 		{
 			name:     "stream error",
@@ -1685,12 +1693,7 @@ func TestCreateSessionConcurrent(t *testing.T) {
 
 			stream := newFakeStream()
 			stream.events <- &event.BrowserEvent{
-				Browser: &browserv1.Browser{
-					Status: browserv1.BrowserStatus{
-						Phase: "Running",
-						PodIP: "127.0.0.1",
-					},
-				},
+				Browser: runningBrowser("127.0.0.1"),
 			}
 
 			fc := &fakeClient{
@@ -1864,4 +1867,439 @@ func TestCreateSessionEventStreamClosed(t *testing.T) {
 	svc.CreateSession(rw, req)
 
 	verifyResponseError(t, rw, http.StatusInternalServerError, selenium.ErrUnknown(ErrInternal))
+}
+
+func browserWithContainerState(podIP string, state corev1.ContainerState) *browserv1.Browser {
+	return &browserv1.Browser{
+		Status: browserv1.BrowserStatus{
+			Phase: "Running",
+			PodIP: podIP,
+			ContainerStatuses: []browserv1.ContainerStatus{
+				{Name: sidecarContainerName, State: state},
+			},
+		},
+	}
+}
+
+func refusedDialErr() error {
+	return &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED}
+}
+
+func TestCreateBrowserWaitsForSeleniferousContainer(t *testing.T) {
+	waiting := corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}}
+
+	stream := newFakeStream()
+	stream.events <- &event.BrowserEvent{Browser: browserWithContainerState("127.0.0.1", waiting)}
+	stream.events <- &event.BrowserEvent{Browser: runningBrowser("127.0.0.1")}
+
+	cc := &captureClient{fakeClient: fakeClient{stream: stream}}
+	svc := NewService(cc, ServiceConfig{Namespace: "ns", SidecarPort: "4444", BrowserStartTimeout: time.Second})
+	req := httptest.NewRequest(http.MethodPost, "/session", nil)
+	rw := httptest.NewRecorder()
+
+	podIP, _, _, ok := svc.createBrowser(rw, req, "chromium", "123", nil, writeCreateSessionWaitError)
+	if !ok {
+		t.Fatalf("expected createBrowser to succeed, status=%d", rw.Code)
+	}
+	if podIP != "127.0.0.1" {
+		t.Fatalf("podIP = %q, want 127.0.0.1", podIP)
+	}
+}
+
+func TestCreateBrowserIgnoresRunningEventWithoutPodIP(t *testing.T) {
+	stream := newFakeStream()
+	stream.events <- &event.BrowserEvent{Browser: runningBrowser("")}
+	stream.events <- &event.BrowserEvent{Browser: runningBrowser("127.0.0.1")}
+
+	cc := &captureClient{fakeClient: fakeClient{stream: stream}}
+	svc := NewService(cc, ServiceConfig{Namespace: "ns", SidecarPort: "4444", BrowserStartTimeout: time.Second})
+	req := httptest.NewRequest(http.MethodPost, "/session", nil)
+	rw := httptest.NewRecorder()
+
+	podIP, _, _, ok := svc.createBrowser(rw, req, "chromium", "123", nil, writeCreateSessionWaitError)
+	if !ok {
+		t.Fatalf("expected createBrowser to succeed, status=%d", rw.Code)
+	}
+	if podIP != "127.0.0.1" {
+		t.Fatalf("podIP = %q, want 127.0.0.1", podIP)
+	}
+}
+
+func TestCreateBrowserTimesOutWhileSeleniferousNeverRuns(t *testing.T) {
+	waiting := corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}}
+
+	stream := newFakeStream()
+	stream.events <- &event.BrowserEvent{Browser: browserWithContainerState("127.0.0.1", waiting)}
+
+	fc := &fakeClient{
+		stream:       stream,
+		createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+	}
+	svc := NewService(fc, ServiceConfig{Namespace: "ns", BrowserStartTimeout: 200 * time.Millisecond})
+	req := newRequestWithParams(http.MethodPost, "/wd/hub/session", bytes.NewBufferString(validCapsBody()), nil)
+	rw := httptest.NewRecorder()
+
+	svc.CreateSession(rw, req)
+
+	verifyResponseError(t, rw, http.StatusInternalServerError,
+		selenium.ErrUnknown(errors.New("browser did not become ready in 200ms (seleniferous: ContainerCreating)")))
+}
+
+func TestIsContainerRunning(t *testing.T) {
+	running := corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}
+	waiting := corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}
+	terminated := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}}
+
+	tests := []struct {
+		name    string
+		browser *browserv1.Browser
+		want    bool
+	}{
+		{"nil browser", nil, false},
+		{"no container statuses", &browserv1.Browser{}, false},
+		{"running", browserWithContainerState("127.0.0.1", running), true},
+		{"waiting", browserWithContainerState("127.0.0.1", waiting), false},
+		{"terminated", browserWithContainerState("127.0.0.1", terminated), false},
+		{
+			"other container only",
+			&browserv1.Browser{
+				Status: browserv1.BrowserStatus{
+					ContainerStatuses: []browserv1.ContainerStatus{
+						{Name: "browser", State: running},
+					},
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isContainerRunning(tt.browser, sidecarContainerName); got != tt.want {
+				t.Fatalf("isContainerRunning() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateSessionRetriesRefusedSidecar(t *testing.T) {
+	fc := &fakeClient{
+		stream:       runningStream("127.0.0.1"),
+		createResult: &browserv1.Browser{ObjectMeta: browserv1.Browser{}.ObjectMeta},
+	}
+
+	var attempts int
+	var lastBody string
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("failed to read proxied body on attempt %d: %v", attempts, err)
+		}
+		lastBody = string(body)
+
+		if attempts < 3 {
+			return nil, refusedDialErr()
+		}
+		return response(http.StatusOK, `{"value":{"sessionId":"orig"}}`), nil
+	})
+
+	setTestTransport(t, rt)
+	svc := NewService(fc, ServiceConfig{
+		Namespace:            "ns",
+		SidecarPort:          "4444",
+		BrowserStartTimeout:  time.Second,
+		SessionCreateTimeout: 5 * time.Second,
+	})
+	req := newRequestWithParams(http.MethodPost, "/wd/hub/session", bytes.NewBufferString(validCapsBody()), nil)
+	req.Host = "example.com"
+	rw := httptest.NewRecorder()
+
+	svc.CreateSession(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+	if lastBody != validCapsBody() {
+		t.Fatalf("unexpected body on retried attempt: %s", lastBody)
+	}
+}
+
+func TestCreateSessionDoesNotRetryOtherProxyErrors(t *testing.T) {
+	fc := &fakeClient{
+		stream:       runningStream("127.0.0.1"),
+		createResult: &browserv1.Browser{ObjectMeta: browserv1.Browser{}.ObjectMeta},
+	}
+
+	var attempts int
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return nil, errors.New("boom")
+	})
+
+	setTestTransport(t, rt)
+	svc := NewService(fc, ServiceConfig{
+		Namespace:            "ns",
+		SidecarPort:          "4444",
+		BrowserStartTimeout:  time.Second,
+		SessionCreateTimeout: 5 * time.Second,
+	})
+	req := newRequestWithParams(http.MethodPost, "/wd/hub/session", bytes.NewBufferString(validCapsBody()), nil)
+	rw := httptest.NewRecorder()
+
+	svc.CreateSession(rw, req)
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rw.Code)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected no retry for a non-refused error, got %d attempts", attempts)
+	}
+}
+
+func TestCreateSessionGivesUpAtDeadline(t *testing.T) {
+	fc := &fakeClient{
+		stream:       runningStream("127.0.0.1"),
+		createResult: &browserv1.Browser{ObjectMeta: browserv1.Browser{}.ObjectMeta},
+	}
+
+	var attempts int
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return nil, refusedDialErr()
+	})
+
+	setTestTransport(t, rt)
+	svc := NewService(fc, ServiceConfig{
+		Namespace:            "ns",
+		SidecarPort:          "4444",
+		BrowserStartTimeout:  time.Second,
+		SessionCreateTimeout: 300 * time.Millisecond,
+	})
+	req := newRequestWithParams(http.MethodPost, "/wd/hub/session", bytes.NewBufferString(validCapsBody()), nil)
+	rw := httptest.NewRecorder()
+
+	start := time.Now()
+	svc.CreateSession(rw, req)
+	elapsed := time.Since(start)
+
+	if rw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rw.Code)
+	}
+	if attempts < 2 {
+		t.Fatalf("expected the dial to be retried, got %d attempts", attempts)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("deadline did not stop the loop: took %v", elapsed)
+	}
+}
+
+func TestMcpHandlerInitRetriesRefusedSidecar(t *testing.T) {
+	fc := &fakeClient{
+		stream:       runningStream("127.0.0.1"),
+		createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+	}
+
+	payload := `{"jsonrpc":"2.0","id":1,"method":"initialize"}`
+
+	var attempts int
+	var lastBody string
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("failed to read proxied body on attempt %d: %v", attempts, err)
+		}
+		lastBody = string(body)
+
+		if attempts < 3 {
+			return nil, refusedDialErr()
+		}
+		return response(http.StatusOK, `{"jsonrpc":"2.0","id":1,"result":{}}`), nil
+	})
+
+	setTestTransport(t, rt)
+	svc := NewService(fc, ServiceConfig{
+		Namespace:            "ns",
+		SidecarPort:          "4444",
+		BrowserStartTimeout:  time.Second,
+		SessionCreateTimeout: 5 * time.Second,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123", bytes.NewBufferString(payload))
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+	if lastBody != payload {
+		t.Fatalf("unexpected body on retried attempt: %s", lastBody)
+	}
+}
+
+func TestMcpHandlerInitBodyReadError(t *testing.T) {
+	fc := &fakeClient{
+		stream:       runningStream("127.0.0.1"),
+		createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+	}
+
+	svc := NewService(fc, ServiceConfig{
+		Namespace:           "ns",
+		SidecarPort:         "4444",
+		BrowserStartTimeout: time.Second,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/mcp?browser=chromium&version=123", nil)
+	req.Body = errorReader{}
+	rw := httptest.NewRecorder()
+
+	svc.McpHandler(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rw.Code)
+	}
+	if !strings.Contains(rw.Body.String(), "failed to read body") {
+		t.Fatalf("unexpected body: %q", rw.Body.String())
+	}
+}
+
+func TestBrowserFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   browserv1.BrowserStatus
+		expected string
+	}{
+		{"message wins", browserv1.BrowserStatus{Reason: "BrowserPodSpec", Message: "ImagePullBackOff"}, "ImagePullBackOff"},
+		{"falls back to reason", browserv1.BrowserStatus{Reason: "BrowserPodSpec"}, "BrowserPodSpec"},
+		{"blank message falls back", browserv1.BrowserStatus{Reason: "BrowserPodSpec", Message: "   "}, "BrowserPodSpec"},
+		{"nothing set", browserv1.BrowserStatus{}, ErrInternal.Error()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := browserFailure(&browserv1.Browser{Status: tt.status})
+			if err.Error() != tt.expected {
+				t.Fatalf("browserFailure() = %q, want %q", err.Error(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestNotReadyError(t *testing.T) {
+	waiting := func(name, reason string) browserv1.ContainerStatus {
+		return browserv1.ContainerStatus{
+			Name:  name,
+			State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason}},
+		}
+	}
+
+	running := browserv1.ContainerStatus{
+		Name:  "browser",
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}
+
+	tests := []struct {
+		name     string
+		browser  *browserv1.Browser
+		expected string
+	}{
+		{"no events", nil, "browser did not become ready in 1m0s (no status received)"},
+		{
+			"waiting sidecar",
+			&browserv1.Browser{Status: browserv1.BrowserStatus{
+				ContainerStatuses: []browserv1.ContainerStatus{running, waiting("seleniferous", "ContainerCreating")},
+			}},
+			"browser did not become ready in 1m0s (seleniferous: ContainerCreating)",
+		},
+		{
+			"several waiting sorted",
+			&browserv1.Browser{Status: browserv1.BrowserStatus{
+				ContainerStatuses: []browserv1.ContainerStatus{waiting("seleniferous", "PodInitializing"), waiting("browser", "ImagePullBackOff")},
+			}},
+			"browser did not become ready in 1m0s (browser: ImagePullBackOff, seleniferous: PodInitializing)",
+		},
+		{
+			"waiting without reason",
+			&browserv1.Browser{Status: browserv1.BrowserStatus{
+				ContainerStatuses: []browserv1.ContainerStatus{waiting("seleniferous", "")},
+			}},
+			"browser did not become ready in 1m0s (seleniferous: Waiting)",
+		},
+		{
+			"nothing waiting",
+			&browserv1.Browser{Status: browserv1.BrowserStatus{
+				Phase:             "Pending",
+				ContainerStatuses: []browserv1.ContainerStatus{running},
+			}},
+			"browser did not become ready in 1m0s (phase Pending)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := notReadyError(tt.browser, time.Minute)
+			if err.Error() != tt.expected {
+				t.Fatalf("notReadyError() = %q, want %q", err.Error(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestCreateSessionFailedEventSurfacesMessage(t *testing.T) {
+	stream := newFakeStream()
+	stream.events <- &event.BrowserEvent{
+		Browser: &browserv1.Browser{
+			Status: browserv1.BrowserStatus{
+				Phase:   "Failed",
+				Reason:  "BrowserPodSpec",
+				Message: "Browser pod container seleniferous failed: ImagePullBackOff",
+			},
+		},
+	}
+
+	fc := &fakeClient{
+		stream:       stream,
+		createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+	}
+	svc := NewService(fc, ServiceConfig{Namespace: "ns", BrowserStartTimeout: time.Second})
+	rw := httptest.NewRecorder()
+
+	svc.CreateSession(rw, newRequestWithParams(http.MethodPost, "/wd/hub/session", bytes.NewBufferString(validCapsBody()), nil))
+
+	if !strings.Contains(rw.Body.String(), "ImagePullBackOff") {
+		t.Fatalf("expected the controller message in the response, got %s", rw.Body.String())
+	}
+}
+
+func TestCreateBrowserClientCancelIsNotReportedAsTimeout(t *testing.T) {
+	stream := newFakeStream()
+
+	fc := &fakeClient{
+		stream:       stream,
+		createResult: &browserv1.Browser{ObjectMeta: metav1.ObjectMeta{Name: "br"}},
+	}
+	svc := NewService(fc, ServiceConfig{Namespace: "ns", BrowserStartTimeout: time.Minute})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := newRequestWithParams(http.MethodPost, "/wd/hub/session", bytes.NewBufferString(validCapsBody()), nil).WithContext(ctx)
+	rw := httptest.NewRecorder()
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	svc.CreateSession(rw, req)
+
+	if strings.Contains(rw.Body.String(), "did not become ready") {
+		t.Fatalf("client cancellation must not be reported as a timeout, got %s", rw.Body.String())
+	}
 }


### PR DESCRIPTION
A browser pod scheduled onto a freshly autoscaled node made the hub dial `seleniferous` before it was listening, and the refusal failed the session outright with a 500.

**Readiness.** `Running` means containers were *created*, not started, and the controller appends the sidecar after the browser container. The hub now accepts a `Running` event only when `status.podIP` is set and the sidecar's container state is `running`, bounded by `BROWSER_STARTUP_TIMEOUT`.

**Retry.** That narrows the race but can't close it — the CRD has no `ready` field, so "process started" isn't "port bound". All three create paths (WebDriver, MCP `initialize`, Playwright WS) now retry a dial that failed at connect — `*net.OpError` with `Op == "dial"` — with 50 ms → 500 ms backoff inside `SESSION_CREATE_TIMEOUT` (30s). The phase, not the errno, is what makes a replay safe: a failed connect wrote no bytes, so a non-idempotent create cannot have been processed. `EOF`, `ECONNRESET` and read timeouts still fail on the first attempt. Paths for an existing session never retry — there a failed dial means the pod is gone, and a prompt 404 is the right answer.

**Diagnostics.** A `Failed` browser now surfaces the controller's `status.message` instead of a fixed string, a real timeout names the containers still waiting (`browser did not become ready in 3m (seleniferous: ContainerCreating)`), and a client disconnect is no longer reported as a timeout.

`SESSION_CREATE_TIMEOUT` was previously set by the chart but never read by the hub; it is now the only knob for the retry budget, and `BROWSER_STARTUP_TIMEOUT` carries the pod wait. The chart change lands separately in selenosis-deploy.

Approach and backoff constants come from #80 by @gaurav517, narrowed to connect-phase errors.